### PR TITLE
0.0.4-beta.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Growatt Modbus Integration for Home Assistant ☀️
 
 ![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange.svg)
-![Version](https://img.shields.io/badge/Version-0.0.4b2-blue.svg)
+![Version](https://img.shields.io/badge/Version-0.0.4b3-blue.svg)
 [![GitHub Issues](https://img.shields.io/github/issues/0xAHA/Growatt_ModbusTCP.svg)](https://github.com/0xAHA/Growatt_ModbusTCP/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/0xAHA/Growatt_ModbusTCP.svg?style=social)](https://github.com/0xAHA/Growatt_ModbusTCP)
 

--- a/custom_components/growatt_modbus/device_profiles.py
+++ b/custom_components/growatt_modbus/device_profiles.py
@@ -276,12 +276,34 @@ INVERTER_PROFILES = {
     # SPH SERIES - Hybrid Storage (Single Phase with Battery)
     # ========================================================================
     
-    "sph_3000_10000": {
-        "name": "SPH Series 3000-10000",
-        "description": "Hybrid inverter with battery storage (3-10kW)",
-        "register_map": "SPH_3000_10000",
+    "sph_3000_6000": {
+        "name": "SPH Series 3000-6000",
+        "description": "Single-phase hybrid inverter with battery storage (3-6kW)",
+        "register_map": "SPH_3000_6000",
         "phases": 1,
-        "has_pv3": False,  # SPH typically has 2 PV inputs
+        "has_pv3": False,
+        "has_battery": True,
+        "max_power_kw": 6.0,
+        "sensors": (
+            BASIC_PV_SENSORS |
+            BASIC_AC_SENSORS |
+            GRID_SENSORS |
+            POWER_FLOW_SENSORS |
+            CONSUMPTION_SENSORS |
+            ENERGY_SENSORS |
+            ENERGY_BREAKDOWN_SENSORS |
+            BATTERY_SENSORS |
+            TEMPERATURE_SENSORS |
+            STATUS_SENSORS
+        ),
+    },
+    
+    "sph_7000_10000": {
+        "name": "SPH Series 7000-10000",
+        "description": "Single-phase hybrid inverter with battery storage (7-10kW)",
+        "register_map": "SPH_7000_10000",
+        "phases": 1,
+        "has_pv3": False,
         "has_battery": True,
         "max_power_kw": 10.0,
         "sensors": (

--- a/custom_components/growatt_modbus/manifest.json
+++ b/custom_components/growatt_modbus/manifest.json
@@ -12,5 +12,5 @@
     "pymodbus>=3.0.0",
     "pyserial>=3.4"
   ],
-  "version": "0.0.4-beta.2"
+  "version": "0.0.4-beta.3"
 }

--- a/custom_components/growatt_modbus/services.yaml
+++ b/custom_components/growatt_modbus/services.yaml
@@ -130,8 +130,12 @@ run_diagnostic:
               value: "min_3000_6000_tl_x"
             - label: "MIN 7000-10000TL-X (3 PV, single-phase, 7-10kW)"
               value: "min_7000_10000_tl_x"
-            - label: "SPH 3000-10000 (Hybrid with battery, 3-10kW)"
-              value: "sph_3000_10000"
+            - label: "SPH 3000-6000 (Single-phase hybrid with battery, 3-6kW)"
+              value: "sph_3000_6000"
+            - label: "SPH 7000-10000 (Single-phase hybrid with battery, 7-10kW)"
+              value: "sph_7000_10000"
+            - label: "SPH-TL3 3000-10000 (3-phase hybrid with battery, 3-10kW)"
+              value: "sph_tl3_3000_10000"
             - label: "MID 15000-25000TL3-X (Three-phase, 15-25kW)"
               value: "mid_15000_25000tl3_x"
             - label: "MOD 6000-15000TL3-XH (Hybrid three-phase, 6-15kW)"
@@ -183,8 +187,10 @@ scan_registers:
       selector:
         select:
           options:
-            - label: "SPH Series - Hybrid with battery (0-124, 1000-1124)"
+            - label: "SPH Series - Single-phase hybrid (0-124)"
               value: "sph"
+            - label: "SPH-TL3 Series - 3-phase hybrid (0-124, 1000-1124)"
+              value: "sph_tl3"
             - label: "MIN Series - String inverter (3000-3124)"
               value: "min"
             - label: "MOD Series - Hybrid with battery (3000-3249)"
@@ -239,8 +245,10 @@ export_register_dump:
       selector:
         select:
           options:
-            - label: "SPH Series - Hybrid with battery"
+            - label: "SPH Series - Single-phase hybrid"
               value: "sph"
+            - label: "SPH-TL3 Series - 3-phase hybrid"
+              value: "sph_tl3"
             - label: "MIN Series - String inverter"
               value: "min"
             - label: "MOD Series - Hybrid with battery"

--- a/custom_components/growatt_modbus/strings.json
+++ b/custom_components/growatt_modbus/strings.json
@@ -75,19 +75,21 @@
   "selector": {
     "inverter_series": {
       "options": {
+        "mac_20000_40000_tl3_x": "MAC 20000-40000TL3-X (3-phase compact, 20-40kW)",
+        "max_1500v_series": "MAX 1500V Series (High-voltage commercial, up to 150kW)",
+        "max_50000_125000_tl3_x": "MAX 50000-125000TL3-X (3-phase commercial, 50-125kW)",
+        "max_x_lv_series": "MAX-X LV Series (Low-voltage commercial, up to 125kW)",
+        "mid_15000_25000_tl3_x": "MID 15000-25000TL3-X (3-phase, 15-25kW)",
         "min_3000_6000_tl_x": "MIN 3000-6000TL-X (Single-phase, 2 PV, 3-6kW)",
         "min_7000_10000_tl_x": "MIN 7000-10000TL-X (Single-phase, 3 PV, 7-10kW)",
+        "mix_series": "MIX Series (Legacy storage inverter)",
+        "mod_6000_15000_tl3_xh": "MOD 6000-15000TL3-XH (3-phase hybrid, 6-15kW)",
+        "spa_series": "SPA Series (AC-coupled storage)",
+        "sph_3000_6000": "SPH 3000-6000 (Single-phase hybrid with battery, 3-6kW)",
+        "sph_7000_10000": "SPH 7000-10000 (Single-phase hybrid with battery, 7-10kW)",
+        "sph_tl3_3000_10000": "SPH-TL3 3000-10000 (3-phase hybrid with battery, 3-10kW)",
         "tl_xh_3000_10000": "TL-XH 3000-10000 (Hybrid with battery, 3-10kW)",
         "tl_xh_us_3000_10000": "TL-XH US 3000-10000 (US Hybrid with battery, 3-10kW)",
-        "mid_15000_25000_tl3_x": "MID 15000-25000TL3-X (3-phase, 15-25kW)",
-        "mac_20000_40000_tl3_x": "MAC 20000-40000TL3-X (3-phase compact, 20-40kW)",
-        "max_50000_125000_tl3_x": "MAX 50000-125000TL3-X (3-phase commercial, 50-125kW)",
-        "max_1500v_series": "MAX 1500V Series (High-voltage commercial, up to 150kW)",
-        "max_x_lv_series": "MAX-X LV Series (Low-voltage commercial, up to 125kW)",
-        "sph_3000_10000": "SPH 3000-10000 (Hybrid with battery, 3-10kW)",
-        "mix_series": "MIX Series (Legacy storage inverter)",
-        "spa_series": "SPA Series (AC-coupled storage)",
-        "mod_6000_15000_tl3_xh": "MOD 6000-15000TL3-XH (3-phase hybrid, 6-15kW)",
         "wit_tl3_series": "WIT TL3 Series (Business storage power, 3-phase)"
       }
     }


### PR DESCRIPTION
v0.0.4-beta3 - SPH TL3 Detection Fix
🐛 Bug Fixes

Fixed SPH profile mapping errors - Resolved "Unknown register map 'SPH_3000_10000'" error
Split SPH profiles into correct variants:

SPH 3000-6000 (single-phase, 3-6kW) → SPH_3000_6000
SPH 7000-10000 (single-phase, 7-10kW) → SPH_7000_10000
SPH-TL3 3000-10000 (3-phase, 3-10kW) → SPH_TL3_3000_10000



✨ Improvements

Added SPH-TL3 detection - Auto-detection now properly identifies 3-phase SPH models

Checks S-phase and T-phase voltages (registers 42, 46)
Validates storage register range (1000+) to distinguish from MOD series


Improved pattern matching - Longest patterns checked first to prevent "SPH10000TL3" matching as "SPH10000"
Better model descriptions - Clearer UI labels differentiating single-phase SPH from 3-phase SPH-TL3
Alphabetically sorted device list - Models now appear in logical order in UI dropdowns
Updated diagnostic services - run_diagnostic, scan_registers, and export_register_dump now support SPH-TL3

📝 Notes

Users with SPH TL3 inverters previously misidentified as MIN or single-phase SPH models should delete and re-add the integration
Manual selection now shows three distinct SPH options instead of one combined entry

Files Changed: device_profiles.py, auto_detection.py, strings.json, services.yaml