### PR TITLE
Fix emulator bug: load_energy registers returning wrong values

### DIFF
--- a/emulator/simulator.py
+++ b/emulator/simulator.py
@@ -610,20 +610,20 @@ class InverterSimulator:
         elif reg_name == 'boost_temp':
             return round(self.values['temperatures']['boost'] / scale)
 
-        # Energy (32-bit pairs)
-        elif 'energy_today_high' in reg_name:
+        # Energy (32-bit pairs) - exclude load_energy which is handled separately
+        elif 'energy_today_high' in reg_name and 'load_energy' not in reg_name:
             combined_scale = reg_def.get('combined_scale', 0.1)
             energy_raw = int(self.energy_today / combined_scale)
             return (energy_raw >> 16) & 0xFFFF
-        elif 'energy_today_low' in reg_name:
+        elif 'energy_today_low' in reg_name and 'load_energy' not in reg_name:
             combined_scale = reg_def.get('combined_scale', 0.1)
             energy_raw = int(self.energy_today / combined_scale)
             return energy_raw & 0xFFFF
-        elif 'energy_total_high' in reg_name:
+        elif 'energy_total_high' in reg_name and 'load_energy' not in reg_name:
             combined_scale = reg_def.get('combined_scale', 0.1)
             energy_raw = int(self.energy_total / combined_scale)
             return (energy_raw >> 16) & 0xFFFF
-        elif 'energy_total_low' in reg_name:
+        elif 'energy_total_low' in reg_name and 'load_energy' not in reg_name:
             combined_scale = reg_def.get('combined_scale', 0.1)
             energy_raw = int(self.energy_total / combined_scale)
             return energy_raw & 0xFFFF


### PR DESCRIPTION
Fixed substring matching issue where 'load_energy_today_low' was incorrectly matching the 'energy_today_low' check, causing load_energy registers to return energy_today values.

Before:
- Register 3076 (load_energy_today_low) returned energy_today value
- Integration showed identical values for PV generation and load consumption

After:
- Added 'load_energy' exclusion to generic energy checks
- load_energy registers now correctly return load_energy_today/total values

Example from logs:
- Was: Energy today=18.7 kWh, Load energy=18.7 kWh (both from reg 187)
- Now: Energy today=18.7 kWh, Load energy=3.7 kWh (correct separate values)