### PR TITLE
Improve MOD auto-detection and fix register scanner 31000 range

### DIFF
--- a/custom_components/growatt_modbus/diagnostic.py
+++ b/custom_components/growatt_modbus/diagnostic.py
@@ -32,13 +32,14 @@ _LOGGER = logging.getLogger(__name__)
 SERVICE_EXPORT_DUMP = "export_register_dump"
 
 # Universal scan ranges - covers all Growatt series
+# Split into chunks of max 125 registers to respect Modbus limits
 UNIVERSAL_SCAN_RANGES = [
     {"name": "Base Range 0-124", "start": 0, "count": 125},
     {"name": "Extended Range 125-249", "start": 125, "count": 125},
     {"name": "Storage Range 1000-1124", "start": 1000, "count": 125},
     {"name": "MIN/MOD Range 3000-3124", "start": 3000, "count": 125},
     {"name": "MOD Extended 3125-3249", "start": 3125, "count": 125},
-    {"name": "MOD Battery/BMS 31100-31299", "start": 31100, "count": 200},  # Covers 31126 battery_power and extended BMS data
+    {"name": "MOD Battery Info 1: 31200-31299", "start": 31200, "count": 100},  # VPP Protocol V2.01 battery data (respects 125-reg limit)
 ]
 
 # Service schema


### PR DESCRIPTION
Auto-detection improvements:
- Check for MOD-specific 31200 range (VPP Protocol battery data) FIRST
- This prevents MOD from being misdetected as SPH TL3
- Emulators serving all registers will now correctly detect as MOD

Register scanner fixes:
- Changed 31100-31299 (200 regs) to 31200-31299 (100 regs)
- Now respects 125-register Modbus limit
- Aligns with official VPP Protocol V2.01 (battery data starts at 31200, not 31100)

Detection order: MOD (31200) → SPH TL3 (1000) → fallback to MOD