### PR TITLE
#59 Bugfix grid import zero

### DIFF
--- a/custom_components/growatt_modbus/sensor.py
+++ b/custom_components/growatt_modbus/sensor.py
@@ -674,15 +674,12 @@ class GrowattModbusSensor(CoordinatorEntity, SensorEntity):
                 export = getattr(data, "power_to_grid", 0)
                 solar = getattr(data, "pv_total_power", 0)
                 load = getattr(data, "power_to_load", 0)
+                charge = getattr(data, "charge_power", 0)
+                discharge = getattr(data, "discharge_power", 0)
                 
-                if export > 0:
-                    # We have export data from registers
-                    grid_power = export
-                elif load > 0 and solar > 0:
-                    # Calculate: positive if exporting, negative if importing
-                    grid_power = solar - load
-                else:
-                    grid_power = 0
+                # Prefer inverter grid register (signed). When it's 0 or unavailable,
+                # fall back to net flow: (solar + battery discharge) - (load + battery charge)
+                grid_power = export if export != 0 else (solar + discharge) - (load + charge)
                 
                 # Apply inversion if configured (CT clamp backwards)
                 if invert_grid_power:
@@ -698,13 +695,11 @@ class GrowattModbusSensor(CoordinatorEntity, SensorEntity):
                 export = getattr(data, "power_to_grid", 0)
                 solar = getattr(data, "pv_total_power", 0)
                 load = getattr(data, "power_to_load", 0)
+                charge = getattr(data, "charge_power", 0)
+                discharge = getattr(data, "discharge_power", 0)
                 
-                if export > 0:
-                    grid_power = export
-                elif load > 0 and solar > 0:
-                    grid_power = solar - load
-                else:
-                    grid_power = 0
+                # Positive means export, negative means import
+                grid_power = export if export != 0 else (solar + discharge) - (load + charge)
                 
                 # Apply inversion if configured
                 if invert_grid_power:
@@ -719,13 +714,11 @@ class GrowattModbusSensor(CoordinatorEntity, SensorEntity):
                 export = getattr(data, "power_to_grid", 0)
                 solar = getattr(data, "pv_total_power", 0)
                 load = getattr(data, "power_to_load", 0)
+                charge = getattr(data, "charge_power", 0)
+                discharge = getattr(data, "discharge_power", 0)
                 
-                if export > 0:
-                    grid_power = export
-                elif load > 0 and solar > 0:
-                    grid_power = solar - load
-                else:
-                    grid_power = 0
+                # Positive means export, negative means import
+                grid_power = export if export != 0 else (solar + discharge) - (load + charge)
                 
                 # Apply inversion if configured
                 if invert_grid_power:


### PR DESCRIPTION
#59 Fix Grid Import/Export calculations so they reflect grid draw when PV is 0 or batteries are involved:
  - Prefer the inverter’s signed grid register when non-zero.
  - Fallback to net power balance `(solar + battery_discharge) - (load + battery_charge)` so deficits become import even with PV=0 and battery idle.
Tested against WIT inverter.