### PR TITLE
Fix battery charge power sign for SPF series

### DIFF
--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -950,14 +950,25 @@ class GrowattModbus:
                 logger.debug(f"Battery power (signed): HIGH={raw_high} (reg {pair_addr}), LOW={raw_low} (reg {addr}) → {battery_power}W")
 
                 # Split into charge/discharge based on sign
+                charge_is_negative = self.register_map.get("negative_battery_power_charge", False)
                 if battery_power > 0:
-                    data.charge_power = battery_power
-                    data.discharge_power = 0.0
-                    logger.debug(f"  → Charging: {data.charge_power}W")
+                    if charge_is_negative:
+                        data.charge_power = 0.0
+                        data.discharge_power = battery_power
+                        logger.debug(f"  → Discharging: {data.discharge_power}W")
+                    else:
+                        data.charge_power = battery_power
+                        data.discharge_power = 0.0
+                        logger.debug(f"  → Charging: {data.charge_power}W")
                 elif battery_power < 0:
-                    data.charge_power = 0.0
-                    data.discharge_power = abs(battery_power)
-                    logger.debug(f"  → Discharging: {data.discharge_power}W")
+                    if charge_is_negative:
+                        data.charge_power = abs(battery_power)
+                        data.discharge_power = 0.0
+                        logger.debug(f"  → Charging: {data.charge_power}W")
+                    else:
+                        data.charge_power = 0.0
+                        data.discharge_power = abs(battery_power)
+                        logger.debug(f"  → Discharging: {data.discharge_power}W")
                 else:
                     data.charge_power = 0.0
                     data.discharge_power = 0.0

--- a/custom_components/growatt_modbus/profiles/spf.py
+++ b/custom_components/growatt_modbus/profiles/spf.py
@@ -18,6 +18,7 @@ SPF_3000_6000_ES_PLUS = {
     'name': 'SPF 3000-6000 ES PLUS',
     'description': 'Off-grid solar inverter with battery storage and AC charging (3-6kW)',
     'notes': 'Uses 0-82 register range. Off-grid system with AC input, battery, and load output. No grid export.',
+    'negative_battery_power_charge': True,
     'input_registers': {
         # System Status
         0: {'name': 'inverter_status', 'scale': 1, 'unit': '', 'desc': '0=Standby, 1=No Use, 2=Discharge, 3=Fault, 4=Flash, 5=PV Charge, 6=AC Charge, 7=Combine Charge, 8=Combine Charge+Bypass, 9=PV Charge+Bypass, 10=AC Charge+Bypass, 11=Bypass, 12=PV Charge+Discharge'},


### PR DESCRIPTION
Fixes swapped charge/discharge sign for the SPF 3k-6k models. Tested on SPF 6000 ES PLUS.