### PR TITLE
Add OffGrid mode UI field to register scan service

### DIFF
--- a/custom_components/growatt_modbus/services.yaml
+++ b/custom_components/growatt_modbus/services.yaml
@@ -126,6 +126,13 @@ export_register_dump:
       default: true
       selector:
         boolean:
+    offgrid_mode:
+      name: OffGrid Mode (SPF Safety)
+      description: "**⚠️ CRITICAL FOR SPF INVERTERS:** Enable this if you have an Off-Grid inverter (SPF 3000-6000 ES PLUS). Off-Grid inverters will experience a POWER RESET if this is disabled. Leave disabled for grid-tied inverters (MIN, SPH, MOD, WIT, etc.)"
+      required: false
+      default: false
+      selector:
+        boolean:
 
 write_register:
   name: Write Modbus Register


### PR DESCRIPTION
Added offgrid_mode parameter to the export_register_dump service UI component with bold warning about SPF power reset danger. This completes the OffGrid safety implementation by making the protection obvious in the Home Assistant UI.

- Field name: "OffGrid Mode (SPF Safety)"
- Includes bold warning: "⚠️ CRITICAL FOR SPF INVERTERS"
- Default: false (backwards compatible)
- Clear instructions for when to enable