### PR TITLE
Read protocol version from right address when using OffGrid profiles

### DIFF
--- a/custom_components/growatt_modbus/coordinator.py
+++ b/custom_components/growatt_modbus/coordinator.py
@@ -593,28 +593,51 @@ class GrowattModbusCoordinator(DataUpdateCoordinator[GrowattData]):
                 # Fallback to profile name
                 self._model_name = profile.get("name", "Unknown Model")
 
-            # Read Protocol version (register 30099)
+            # Read Protocol version (register 30099 for VPP, 73 for offgrid)
             # If readable, shows actual protocol version (e.g., 2.01, 2.02, etc.)
-            try:
-                result = self._client.client.read_holding_registers(address=30099, count=1, device_id=self._slave_id)
-                if not result.isError() and len(result.registers) > 0:
-                    version_value = result.registers[0]
-                    if version_value > 0:
-                        # Format as version string (e.g., 201 -> "Protocol 2.01", 202 -> "Protocol 2.02")
-                        major = version_value // 100
-                        minor = version_value % 100
-                        self._protocol_version = f"Protocol {major}.{minor:02d}"
-                        _LOGGER.info(f"Detected protocol version: {self._protocol_version} (register 30099 = {version_value})")
+            if not profile.get("offgrid_protocol", False):
+                try:
+                    result = self._client.client.read_holding_registers(address=30099, count=1, device_id=self._slave_id)
+                    if not result.isError() and len(result.registers) > 0:
+                        version_value = result.registers[0]
+                        if version_value > 0:
+                            # Format as version string (e.g., 201 -> "Protocol 2.01", 202 -> "Protocol 2.02")
+                            major = version_value // 100
+                            minor = version_value % 100
+                            self._protocol_version = f"Protocol {major}.{minor:02d}"
+                            _LOGGER.info(f"Detected protocol version: {self._protocol_version} (register 30099 = {version_value})")
+                        else:
+                            self._protocol_version = "Protocol Legacy"
+                            _LOGGER.info("Protocol version register returned 0, using Protocol Legacy")
                     else:
+                        # Register not available - likely legacy protocol
                         self._protocol_version = "Protocol Legacy"
-                        _LOGGER.info("Protocol version register returned 0, using Protocol Legacy")
-                else:
-                    # Register not available - likely legacy protocol
+                        _LOGGER.debug("Could not read register 30099, assuming Protocol Legacy")
+                except Exception as e:
+                    _LOGGER.debug(f"Could not read protocol version (30099): {e}")
                     self._protocol_version = "Protocol Legacy"
-                    _LOGGER.debug("Could not read register 30099, assuming Protocol Legacy")
-            except Exception as e:
-                _LOGGER.debug(f"Could not read protocol version (30099): {e}")
-                self._protocol_version = "Protocol Legacy"
+            else:
+                # OffGrid profile selected
+                try:
+                    result = self._client.client.read_holding_registers(address=73, count=1, device_id=self._slave_id)
+                    if not result.isError() and len(result.registers) > 0:
+                        version_value = result.registers[0]
+                        if version_value > 0:
+                            # Format as version string (e.g., 201 -> "Protocol 2.01", 202 -> "Protocol 2.02")
+                            major = version_value // 100
+                            minor = version_value % 100
+                            self._protocol_version = f"Modbus {major}.{minor:02d}"
+                            _LOGGER.info(f"Detected protocol version: {self._protocol_version} (register 73 = {version_value})")
+                        else:
+                            self._protocol_version = "OffGrid Modbus"
+                            _LOGGER.info("Protocol version register returned 0, using OffGrid Modbus")
+                    else:
+                        # Register not available - likely legacy protocol
+                        self._protocol_version = "OffGrid Modbus"
+                        _LOGGER.debug("Could not read register 73, assuming OffGrid Modbus")
+                except Exception as e:
+                    _LOGGER.debug(f"Could not read protocol version (73): {e}")
+                    self._protocol_version = "OffGrid Modbus"
 
         except Exception as e:
             _LOGGER.error(f"Error reading device identification: {e}")

--- a/custom_components/growatt_modbus/profiles/spf.py
+++ b/custom_components/growatt_modbus/profiles/spf.py
@@ -30,6 +30,7 @@ SPF_3000_6000_ES_PLUS = {
     'name': 'SPF 3000-6000 ES PLUS',
     'description': 'Off-grid solar inverter with battery storage and AC charging (3-6kW)',
     'notes': 'Uses 0-82 register range. Off-grid system with AC input, battery, and load output. No grid export.',
+    'offgrid_protocol': True,
     'input_registers': {
         # System Status
         0: {'name': 'inverter_status', 'scale': 1, 'unit': '', 'desc': '0=Standby, 1=No Use, 2=Discharge, 3=Fault, 4=Flash, 5=PV Charge, 6=AC Charge, 7=Combine Charge, 8=Combine Charge+Bypass, 9=PV Charge+Bypass, 10=AC Charge+Bypass, 11=Bypass, 12=PV Charge+Discharge'},


### PR DESCRIPTION
Fixes part of issue #88, avoiding using an illegal address when the component loads to get the protocol version of the inverter. This will avoid causing a reset of the inverter on component reload and on Home Assistant reboots when using firmwares affected by the reset bug (like SPF 6000 ES PLUS on firmware v100.05)

Instead of using register 30099 it will use holding register 73, as per documentation it's supposed to be the Modbus version. My own inverter reads 0, but it might be different on a newer firmware version. Falls back to "OffGrid Modbus" in case. 
<img width="431" height="236" alt="image" src="https://github.com/user-attachments/assets/b5138285-1c7f-493c-824b-28dc355c170a" />
