### PR TITLE
Fix SPF charge current max values - change from 400A to 80A hardware …

### DIFF
--- a/custom_components/growatt_modbus/profiles/spf.py
+++ b/custom_components/growatt_modbus/profiles/spf.py
@@ -195,8 +195,8 @@ SPF_3000_6000_ES_PLUS = {
 
         # AC Charge Current
         38: {'name': 'ac_charge_current', 'scale': 1, 'unit': 'A', 'access': 'RW',
-             'valid_range': (0, 400),
-             'desc': 'AC charging current limit'},
+             'valid_range': (0, 80),
+             'desc': 'AC charging current limit (SPF 6000 hardware max: 80A)'},
 
         # Battery Type
         39: {'name': 'battery_type', 'scale': 1, 'unit': '', 'access': 'RW',
@@ -215,8 +215,8 @@ SPF_3000_6000_ES_PLUS = {
 
         # Generator Charge Current
         83: {'name': 'gen_charge_current', 'scale': 1, 'unit': 'A', 'access': 'RW',
-             'valid_range': (0, 400),
-             'desc': 'Generator charging current limit'},
+             'valid_range': (0, 80),
+             'desc': 'Generator charging current limit (SPF 6000 hardware max: 80A)'},
 
         # AC to Battery Voltage/SOC Switch Point
         # BATTERY TYPE DEPENDENT (see register 39)


### PR DESCRIPTION
…limit

Changed registers 38 and 83 valid_range from (0, 400) to (0, 80) to match SPF 6000 ES PLUS actual hardware capability.

While the OffGrid protocol specification allows 0~400A (to accommodate different SPF models 3-6kW), the SPF 6000 ES PLUS hardware is limited to 80A maximum charging current due to hardware component ratings.

This fix prevents users from attempting to set dangerously high charge current values that exceed hardware capabilities.

Registers modified:
- Register 38: ac_charge_current (0-80A)
- Register 83: gen_charge_current (0-80A)