### PR TITLE
#105 Fix missing UnitOfApparentPower import in sensor.py

### DIFF
--- a/custom_components/growatt_modbus/sensor.py
+++ b/custom_components/growatt_modbus/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    UnitOfApparentPower,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,


### PR DESCRIPTION
The `ac_apparent_power` sensor definition uses `UnitOfApparentPower.VOLT_AMPERE` but the import was missing, causing a NameError on startup:

    NameError: name 'UnitOfApparentPower' is not defined

This broke the integration completely in v0.1.7.