### PR TITLE
Fix missing UnitOfApparentPower import in sensor.py

### DIFF
--- a/custom_components/growatt_modbus/sensor.py
+++ b/custom_components/growatt_modbus/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    UnitOfApparentPower,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,


### PR DESCRIPTION
Critical fix for sensor platform load error.

Error:
NameError: name 'UnitOfApparentPower' is not defined at line 161

Cause:
Added ac_apparent_power sensor in previous commit but forgot to import UnitOfApparentPower from homeassistant.const

Fix:
Added UnitOfApparentPower to imports from homeassistant.const

This was introduced when adding SPF AC apparent power sensor support.