### PR TITLE
Fix _find_register_by_name to support maps_to attribute (#108)

### DIFF
--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -945,7 +945,7 @@ class GrowattModbus:
 
 
     def _find_register_by_name(self, name: str) -> Optional[int]:
-        """Find register address by its name or alias"""
+        """Find register address by its name, alias, or maps_to attribute"""
         input_regs = self.register_map['input_registers']
         for addr, reg_info in input_regs.items():
             # Check exact name match
@@ -953,6 +953,9 @@ class GrowattModbus:
                 return addr
             # Check alias match (for 3-phase compatibility)
             if reg_info.get('alias') == name:
+                return addr
+            # Check maps_to match (for VPP registers that map to standard names)
+            if reg_info.get('maps_to') == name:
                 return addr
         return None
     


### PR DESCRIPTION
The WIT profile defines battery_temp_vpp at register 31223 with maps_to: 'battery_temp', but _find_register_by_name only checked name and alias attributes, causing battery temperature to always return 0.