### PR TITLE
Add SPH_8000_10000_HU to manual profile selection

### DIFF
--- a/custom_components/growatt_modbus/device_profiles.py
+++ b/custom_components/growatt_modbus/device_profiles.py
@@ -436,6 +436,29 @@ INVERTER_PROFILES = {
         ),
     },
 
+    "sph_8000_10000_hu": {
+        "name": "SPH/SPM 8000-10000TL-HU",
+        "description": "Single-phase hybrid inverter with battery and 3 MPPT inputs (8-10kW)",
+        "register_map": "SPH_8000_10000_HU",
+        "phases": 1,
+        "has_pv3": True,
+        "has_battery": True,
+        "max_power_kw": 10.0,
+        "sensors": (
+            BASIC_PV_SENSORS |
+            PV3_SENSORS |
+            BASIC_AC_SENSORS |
+            GRID_SENSORS |
+            POWER_FLOW_SENSORS |
+            CONSUMPTION_SENSORS |
+            ENERGY_SENSORS |
+            ENERGY_BREAKDOWN_SENSORS |
+            BATTERY_SENSORS |
+            TEMPERATURE_SENSORS |
+            STATUS_SENSORS
+        ),
+    },
+
     # SPH V2.01 VPP Protocol
     "sph_3000_6000_v201": {
         "name": "SPH Series 3-6kW (V2.01)",

--- a/custom_components/growatt_modbus/strings.json
+++ b/custom_components/growatt_modbus/strings.json
@@ -96,6 +96,7 @@
         "mod_6000_15000_tl3_xh": "MOD 6000-15000TL3-XH (3-phase hybrid, 6-15kW)",
         "sph_3000_6000": "SPH 3000-6000 (Single-phase hybrid with battery, 3-6kW)",
         "sph_7000_10000": "SPH 7000-10000 (Single-phase hybrid with battery, 7-10kW)",
+        "sph_8000_10000_hu": "SPH/SPM 8000-10000TL-HU (Single-phase hybrid, 3 MPPT, 8-10kW)",
         "sph_tl3_3000_10000": "SPH-TL3 3000-10000 (3-phase hybrid with battery, 3-10kW)",
         "tl_xh_3000_10000": "TL-XH 3000-10000 (Hybrid with battery, 3-10kW)",
         "tl_xh_us_3000_10000": "TL-XH US 3000-10000 (US Hybrid with battery, 3-10kW)",

--- a/custom_components/growatt_modbus/translations/en.json
+++ b/custom_components/growatt_modbus/translations/en.json
@@ -95,6 +95,7 @@
         "mod_6000_15000_tl3_xh": "MOD 6-15K (3Ph Hybrid)",
         "sph_3000_6000": "SPH 3-6K (1Ph Hybrid)",
         "sph_7000_10000": "SPH 7-10K (1Ph Hybrid)",
+        "sph_8000_10000_hu": "SPH/SPM 8-10K HU (1Ph, 3MPPT)",
         "sph_tl3_3000_10000": "SPH-TL3 3-10K (3Ph Hybrid)",
         "spf_3000_6000_es_plus": "SPF 3-6K (Off-grid)",
         "tl_xh_3000_10000": "MIN 3-10K TL-XH (1Ph Hybrid)",


### PR DESCRIPTION
PROFILE SELECTION UPDATES:
- Added profile to device_profiles.py INVERTER_PROFILES
- Added UI translations to strings.json
- Added UI translations to translations/en.json

PROFILE DETAILS:
- Profile key: sph_8000_10000_hu
- Name: "SPH/SPM 8000-10000TL-HU"
- Description: "Single-phase hybrid, 3 MPPT, 8-10kW"
- Register map: SPH_8000_10000_HU
- Phases: 1 (single-phase)
- has_pv3: True (3 MPPT inputs)
- has_battery: True
- Max power: 10kW

SENSORS INCLUDED:
- Basic PV sensors (PV1, PV2)
- PV3 sensors (voltage, current, power)
- Basic AC sensors
- Grid sensors
- Power flow sensors
- Energy sensors + breakdown
- Battery sensors
- Temperature sensors
- Status sensors

Users can now manually select this profile during setup or reconfiguration if auto-detection doesn't work or if they prefer manual selection.