### PR TITLE
Fix SPH 10000TL-HU battery controls and BMS sensor visibility

### DIFF
--- a/custom_components/growatt_modbus/profiles/sph.py
+++ b/custom_components/growatt_modbus/profiles/sph.py
@@ -385,11 +385,16 @@ SPH_8000_10000_HU = {
         1120: {'name': 'bms_min_soc', 'scale': 1, 'unit': '%', 'desc': 'Parallel minimum SOC'},
     },
     'holding_registers': {
-        # SPH HU has full 1000-1124 holding register range for battery controls
-        # Inherits all battery management registers from SPH_7000_10000
-        **SPH_7000_10000['holding_registers'],
+        # SPH HU uses different register architecture than SPH 7-10kW
+        # Battery management registers (1044, 1070-1071, 1090-1092, 1100-1108) return Modbus exceptions
+        # These settings must be configured via Growatt ShinePhone app or inverter LCD
+        # 1000+ range has INPUT registers (BMS data) but NOT corresponding HOLDING registers
 
-        # HU-specific control (in addition to inherited registers)
+        # Basic Control (0-10 range)
+        0: {'name': 'on_off', 'scale': 1, 'unit': '', 'access': 'RW', 'desc': '0=Off, 1=On'},
+        3: {'name': 'active_power_rate', 'scale': 1, 'unit': '%', 'access': 'RW'},
+
+        # HU-specific control (1000+ range)
         1008: {'name': 'system_enable', 'scale': 1, 'unit': '', 'access': 'RW',
                'desc': 'System enable control',
                'values': {


### PR DESCRIPTION
REVERTS previous incorrect "restoration" of battery control registers.
Refers to issue #83 
**Root Cause Analysis from User Logs:**
```
Modbus error reading holding registers 1044-1044: ExceptionResponse
Modbus error reading holding registers 1070-1071: ExceptionResponse
Modbus error reading holding registers 1090-1092: ExceptionResponse
Modbus error reading holding registers 1100-1108: ExceptionResponse
```

**Register Architecture Discovered:**
- INPUT registers 1090-1092 exist (BMS sensors: max_current, gauge_rm, gauge_fcc) ✅
- HOLDING registers 1044, 1070-1071, 1090-1092, 1100-1108 DON'T exist ❌
- Writing to holding register 1090/1092 fails because they're INPUT registers (read-only)

**SPH HU Profile Changes:**
- Removed inheritance of SPH_7000_10000 holding registers
- Only includes registers that actually work: 0 (on_off), 3 (active_power_rate), 1008 (system_enable)
- Documents that battery management (grid charge, rates, SOC limits, scheduling) must be done via Growatt app/LCD

**Sensor Fixes (unchanged from previous):**
- Removed `> 0` conditions from bms_cycle_count and bms_soh
- Sensors now visible even when reporting 0 values

**Release Notes Updated:**
- Corrected SPH HU section to reflect actual hardware behavior
- Explains register collision (INPUT vs HOLDING at same addresses)
- Provides clear instructions: use Growatt app for battery management
- Documents which controls ARE available in HA (on/off, power rate, system enable)

**User Impact:**
✅ No more Modbus exception errors
✅ Fast, clean polling (doesn't try to read non-existent registers) ✅ BMS sensors visible even when 0
✅ Clear documentation about battery configuration via app ❌ Battery management controls (charge/discharge rates, scheduling) not available in HA - must use Growatt app

This is a hardware/firmware limitation of the SPH HU model, not an integration bug.