### PR TITLE
Fix battery power reading for fallback range (3000) systems

### DIFF
--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -1604,15 +1604,17 @@ class GrowattModbus:
 
         # Filter addresses by preferred range
         if preferred_range == 'vpp':
-            # Prefer VPP range (31000+), fallback to others if not available
+            # Prefer VPP range (31000+), strict - no fallback
             preferred_addrs = [a for a in addresses if a >= 31000]
             if not preferred_addrs:
-                preferred_addrs = addresses  # Use whatever is available
+                # Register doesn't exist in VPP range - return None to trigger fallback logic
+                return None
         else:  # 'fallback' or 'unknown'
-            # Prefer fallback range (1000-3999), fallback to others if not available
+            # Prefer fallback range (1000-3999), strict - no fallback
             preferred_addrs = [a for a in addresses if 1000 <= a < 4000]
             if not preferred_addrs:
-                preferred_addrs = addresses  # Use whatever is available
+                # Register doesn't exist in fallback range - return None to trigger alternative registers
+                return None
 
         # Return the first address from preferred range
         return preferred_addrs[0]

--- a/custom_components/growatt_modbus/profiles/tl_xh.py
+++ b/custom_components/growatt_modbus/profiles/tl_xh.py
@@ -320,6 +320,14 @@ MIN_TL_XH_3000_10000_V201 = {
         3171: {'name': 'battery_soc', 'scale': 1, 'unit': '%', 'desc': 'Battery SOC (primary source for MIN TL-XH)'},
         3176: {'name': 'battery_temp', 'scale': 0.1, 'unit': '°C', 'signed': True, 'desc': 'Battery temperature (primary source for MIN TL-XH)'},
 
+        # === BATTERY ENERGY REGISTERS (3125-3130) ===
+        # Battery energy totals in fallback 3000 range (similar to MOD series)
+        # These are fallback registers when VPP 31200+ is not available
+        3125: {'name': 'discharge_energy_today_high', 'scale': 1, 'unit': '', 'pair': 3126, 'desc': 'Battery discharge energy today HIGH (fallback range)'},
+        3126: {'name': 'discharge_energy_today_low', 'scale': 1, 'unit': '', 'pair': 3125, 'combined_scale': 0.1, 'combined_unit': 'kWh', 'desc': 'Battery discharge energy today (fallback range)'},
+        3129: {'name': 'charge_energy_today_high', 'scale': 1, 'unit': '', 'pair': 3130, 'desc': 'Battery charge energy today HIGH (fallback range)'},
+        3130: {'name': 'charge_energy_today_low', 'scale': 1, 'unit': '', 'pair': 3129, 'combined_scale': 0.1, 'combined_unit': 'kWh', 'desc': 'Battery charge energy today (fallback range)'},
+
         # === BATTERY POWER REGISTERS (3178-3181) ===
         # Some TL-XH models provide unsigned battery power in addition to VPP 31200+ signed power
         # These are fallback registers when VPP 31200+ is not available


### PR DESCRIPTION
Issue: Battery power was reading from VPP range (31200-31201) even when the system was detected as using fallback range (3000), resulting in zero values. The fallback range uses separate unsigned charge/discharge registers instead of a single signed battery_power register.

Changes:
1. Fixed _find_register_by_name_with_fallback() to return None when a register doesn't exist in the detected range, instead of falling back to other ranges. This ensures the code properly uses alternative registers (charge_power_low/discharge_power_low) when battery_power_low doesn't exist in the fallback range.

2. Added battery energy registers in 3000 range (3125-3130) to MIN TL-XH profile, matching MOD series layout. These provide charge/discharge energy today for systems that don't support VPP range (31200+).

This fix ensures battery power and energy values display correctly for MIN TL-XH inverters that only support the 3000 register range.

https://claude.ai/code/session_01B2keiRu2cQRhYhXdJxRx8T