### PR TITLE
v0.6.8b2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Growatt Modbus Integration for Home Assistant ☀️
 
 ![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange.svg)
-![Version](https://img.shields.io/badge/Version-0.6.8b1-blue.svg)
+![Version](https://img.shields.io/badge/Version-0.6.8b2-blue.svg)
 [![GitHub Issues](https://img.shields.io/github/issues/0xAHA/Growatt_ModbusTCP.svg)](https://github.com/0xAHA/Growatt_ModbusTCP/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/0xAHA/Growatt_ModbusTCP.svg?style=social)](https://github.com/0xAHA/Growatt_ModbusTCP)
 
@@ -294,6 +294,11 @@ The integration pre-configures sensors with the correct `state_class` and `devic
 ## What's New
 
 See **[RELEASENOTES.md](RELEASENOTES.md)** for the full changelog.
+
+**v0.6.8b2 highlights:**
+
+- **MOD GEN4 TOU enable/priority no longer reverts** — enable and priority selects now write start+end as an atomic FC16 pair (same as time pickers), fixing the firmware's requirement for both registers in a single transaction. This is why the Solax integration works with the ShineWiFi dongle connected.
+- **Duplicate "Allow Grid Charge" entity fixed** — the correct battery-device-assigned entity is now registered; the generic duplicate is suppressed.
 
 **v0.6.8b1 highlights:**
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,38 @@
 
 ---
 
+## v0.6.8b2
+
+Issues: #234
+
+> **Beta release** — MOD GEN4 TOU enable/priority reversion fix + duplicate entity fix.
+> Supersedes v0.6.8b1 for MOD GEN4 users.
+
+---
+
+### Changes
+
+- **MOD GEN4 — TOU enable/priority no longer reverts (#234):** `GrowattModTouEnable` and
+  `GrowattModTouPriority` previously wrote only the start register (FC06 single-register
+  write). The MOD GEN4 firmware requires start and end to be written together in a single
+  FC16 transaction — exactly the same constraint that caused TOU time writes to revert
+  before v0.6.8b1. Both selects now write `[start, end]` atomically via `write_registers`,
+  matching the pattern already used by `GrowattModTouTime` in `time.py` and by the
+  `wills106/homeassistant-solax-modbus` Growatt plugin. This is why the Solax integration
+  works with the ShineWiFi dongle connected without needing to disconnect it.
+
+- **MOD GEN4 — Duplicate "Allow Grid Charge" entity fixed (#234):** The `allow_grid_charge`
+  select was being registered twice — once by the generic `WRITABLE_REGISTERS` loop and
+  once by the dedicated `GrowattModAllowGridChargeSelect` class — producing identical unique
+  IDs. Home Assistant registered the first (generic) entity and silently discarded the
+  second (battery-device-assigned) one, logging
+  `ID …_allow_grid_charge already exists — ignoring select.growatt_modbus_battery_allow_grid_charge`.
+  A skip guard now prevents the generic loop from creating this entity, leaving only the
+  dedicated class. The "Allow Grid Charge" entity now correctly appears under the Battery
+  device.
+
+---
+
 ## v0.6.8b1
 
 Issues: #228 · #226

--- a/custom_components/growatt_modbus/manifest.json
+++ b/custom_components/growatt_modbus/manifest.json
@@ -12,5 +12,5 @@
     "pymodbus>=3.0.0",
     "pyserial>=3.4"
   ],
-  "version": "0.6.8b1"
+  "version": "0.6.8b2"
 }

--- a/custom_components/growatt_modbus/select.py
+++ b/custom_components/growatt_modbus/select.py
@@ -86,6 +86,10 @@ async def async_setup_entry(
         if register_num not in holding_registers:
             continue  # Skip if register not in this profile
 
+        # allow_grid_charge is handled by GrowattModAllowGridChargeSelect below
+        if control_name == 'allow_grid_charge':
+            continue
+
         # VPP export limit requires live confirmation that the inverter responds to 30200
         if control_name == 'vpp_export_limit_enable':
             if coordinator.data is None or not coordinator.data.vpp_export_limit_available:
@@ -615,7 +619,9 @@ class GrowattModTouPriority(CoordinatorEntity, SelectEntity):
         self._config_entry = config_entry
         self._period = period_def["period"]
         self._start_reg = period_def["start_reg"]
+        self._end_reg = period_def["end_reg"]
         self._start_field = period_def["start_field"]
+        self._end_field = period_def["end_field"]
 
         entry_name = config_entry.data.get("name", config_entry.title)
         self._attr_name = f"{entry_name} TOU Period {self._period} Priority"
@@ -637,26 +643,27 @@ class GrowattModTouPriority(CoordinatorEntity, SelectEntity):
         return self._PRIORITY_MAP.get(priority)
 
     async def async_select_option(self, option: str) -> None:
-        """Write new priority, preserving time and enable bits."""
+        """Write new priority atomically — always write start+end together as a single FC16 transaction."""
         priority = self._PRIORITY_REVERSE.get(option)
         if priority is None:
             return
         data = self.coordinator.data
         current_raw = getattr(data, self._start_field, 0) if data else 0
         new_raw = (int(current_raw) & 0x9FFF) | (priority << 13)
+        current_end = int(getattr(data, self._end_field, 0) if data else 0)
         try:
-            write_ok, verified = await self.hass.async_add_executor_job(
-                self.coordinator.modbus_client.write_register_verified, self._start_reg, new_raw,
+            success = await self.hass.async_add_executor_job(
+                self.coordinator.modbus_client.write_registers,
+                self._start_reg,
+                [new_raw, current_end],
             )
         except ModbusWriteError:
-            _LOGGER.error("Failed to write MOD TOU period %d priority (register %d)", self._period, self._start_reg)
+            _LOGGER.error("Failed to write MOD TOU period %d priority (register %d, atomic FC16)", self._period, self._start_reg)
             return
-        if write_ok:
-            if verified:
-                _LOGGER.info("Set MOD TOU period %d priority to %s (raw=0x%04X, verified)", self._period, option, new_raw)
-            else:
-                _LOGGER.warning("MOD TOU period %d priority: write succeeded but value reverted (possible cloud override)", self._period)
+        if success:
+            _LOGGER.info("Set MOD TOU period %d priority to %s (start=0x%04X, end=0x%04X, atomic FC16)", self._period, option, new_raw, current_end)
             self.coordinator.track_write(self._start_reg, new_raw, self._start_field)
+            self.coordinator.track_write(self._end_reg, current_end, self._end_field)
             await self.coordinator.async_request_refresh()
 
 
@@ -677,7 +684,9 @@ class GrowattModTouEnable(CoordinatorEntity, SelectEntity):
         self._config_entry = config_entry
         self._period = period_def["period"]
         self._start_reg = period_def["start_reg"]
+        self._end_reg = period_def["end_reg"]
         self._start_field = period_def["start_field"]
+        self._end_field = period_def["end_field"]
 
         entry_name = config_entry.data.get("name", config_entry.title)
         self._attr_name = f"{entry_name} TOU Period {self._period} Enable"
@@ -699,24 +708,25 @@ class GrowattModTouEnable(CoordinatorEntity, SelectEntity):
         return "Enabled" if enabled else "Disabled"
 
     async def async_select_option(self, option: str) -> None:
-        """Write new enable state, preserving time and priority bits."""
+        """Write new enable state atomically — always write start+end together as a single FC16 transaction."""
         enable = 1 if option == "Enabled" else 0
         data = self.coordinator.data
         current_raw = getattr(data, self._start_field, 0) if data else 0
         new_raw = (int(current_raw) & 0x7FFF) | (enable << 15)
+        current_end = int(getattr(data, self._end_field, 0) if data else 0)
         try:
-            write_ok, verified = await self.hass.async_add_executor_job(
-                self.coordinator.modbus_client.write_register_verified, self._start_reg, new_raw,
+            success = await self.hass.async_add_executor_job(
+                self.coordinator.modbus_client.write_registers,
+                self._start_reg,
+                [new_raw, current_end],
             )
         except ModbusWriteError:
-            _LOGGER.error("Failed to write MOD TOU period %d enable (register %d)", self._period, self._start_reg)
+            _LOGGER.error("Failed to write MOD TOU period %d enable (register %d, atomic FC16)", self._period, self._start_reg)
             return
-        if write_ok:
-            if verified:
-                _LOGGER.info("Set MOD TOU period %d enable to %s (raw=0x%04X, verified)", self._period, option, new_raw)
-            else:
-                _LOGGER.warning("MOD TOU period %d enable: write succeeded but value reverted (possible cloud override)", self._period)
+        if success:
+            _LOGGER.info("Set MOD TOU period %d enable to %s (start=0x%04X, end=0x%04X, atomic FC16)", self._period, option, new_raw, current_end)
             self.coordinator.track_write(self._start_reg, new_raw, self._start_field)
+            self.coordinator.track_write(self._end_reg, current_end, self._end_field)
             await self.coordinator.async_request_refresh()
 
 


### PR DESCRIPTION
v0.6.8b2

Issues: #234

> **Beta release** — MOD GEN4 TOU enable/priority reversion fix + duplicate entity fix.
> Supersedes v0.6.8b1 for MOD GEN4 users.

---

### Changes

- **MOD GEN4 — TOU enable/priority no longer reverts (#234):** `GrowattModTouEnable` and
  `GrowattModTouPriority` previously wrote only the start register (FC06 single-register
  write). The MOD GEN4 firmware requires start and end to be written together in a single
  FC16 transaction — exactly the same constraint that caused TOU time writes to revert
  before v0.6.8b1. Both selects now write `[start, end]` atomically via `write_registers`,
  matching the pattern already used by `GrowattModTouTime` in `time.py` and by the
  `wills106/homeassistant-solax-modbus` Growatt plugin. This is why the Solax integration
  works with the ShineWiFi dongle connected without needing to disconnect it.
- **MOD GEN4 — Duplicate "Allow Grid Charge" entity fixed (#234):** The `allow_grid_charge`
  select was being registered twice — once by the generic `WRITABLE_REGISTERS` loop and
  once by the dedicated `GrowattModAllowGridChargeSelect` class — producing identical unique
  IDs. Home Assistant registered the first (generic) entity and silently discarded the
  second (battery-device-assigned) one, logging
  `ID …_allow_grid_charge already exists — ignoring select.growatt_modbus_battery_allow_grid_charge`.
  A skip guard now prevents the generic loop from creating this entity, leaving only the
  dedicated class. The "Allow Grid Charge" entity now correctly appears under the Battery
  device.