### PR TITLE
SPH: add Load First Battery Minimum SOC control (register 608)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,29 @@
 
 ---
 
+## vNext
+
+### SPH Hybrid — Load First Battery Minimum SOC control
+
+Added a slider control entity for Growatt SPH hybrid inverters
+(3-6kW, 7-10kW, and their V2.01 variants) that sets the minimum
+battery state-of-charge the inverter will discharge to when
+operating in **Load First** mode.
+
+- **Register:** holding register 608 (undocumented in official
+  Growatt Modbus V1.39 spec; sourced from community research and
+  cross-validated against the homeassistant-solax-modbus
+  plugin_growatt.py implementation)
+- **Range:** 10–100 %
+- **HA entity:** `number.<name>_battery_load_first_battery_minimum_soc`
+- **Device:** Battery device
+- **Icon:** `mdi:battery-sync`
+- **Applies to:** SPH_3000_6000, SPH_7000_10000,
+  SPH_3000_6000_V201, SPH_7000_10000_V201
+
+
+---
+
 ## v0.6.8b2
 
 Issues: #234

--- a/custom_components/growatt_modbus/const.py
+++ b/custom_components/growatt_modbus/const.py
@@ -350,6 +350,16 @@ WRITABLE_REGISTERS = {
         'unit': '%',
         'desc': 'SOC level to stop battery discharge'
     },
+    # Not in official Growatt Modbus protocol documentation.
+    # Source: https://www.photovoltaikforum.com/thread/192228-growatt-sph-modbus-rtu-rj45-pinout-und-register-beschreibung/?postID=3017838#post3017838
+    # Also used by the homeassistant-solax-modbus plugin_growatt.py (register 608, GEN3/SPH).
+    'load_first_battery_minimum_soc': {
+        'register': 608,
+        'scale': 1,
+        'valid_range': (10, 100),
+        'unit': '%',
+        'desc': 'Minimum battery SOC in Load First mode — inverter stops discharging below this level'
+    },
     'charge_power_rate': {
         'register': 1090,
         'scale': 1,

--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -244,6 +244,7 @@ class GrowattData:
 
     # SPH/SPM Battery Control registers (1000+ range)
     priority_mode: int = 0            # 0=Load First, 1=Battery First, 2=Grid First
+    load_first_battery_minimum_soc: int = 10  # 10-100 (min SOC % in Load First mode, register 608)
     discharge_power_rate: int = 0     # 0-100 (battery discharge power %)
     discharge_stopped_soc: int = 0    # 0-100 (stop discharge at SOC %)
     charge_power_rate: int = 0        # 0-100 (battery charge power %)

--- a/custom_components/growatt_modbus/number.py
+++ b/custom_components/growatt_modbus/number.py
@@ -138,6 +138,7 @@ class GrowattGenericNumber(CoordinatorEntity, NumberEntity):
             'export_limit_w': 'VPP Export Limit (W)',
             'max_output_power_rate': 'Max Output Power Rate',
             'vpp_export_limit_power_rate': 'VPP Export Limit Power Rate',
+            'load_first_battery_minimum_soc': 'Load First Battery Minimum SOC',
         }
         friendly_name = friendly_overrides.get(control_name, control_name.replace('_', ' ').title())
         self._attr_name = friendly_name
@@ -159,6 +160,7 @@ class GrowattGenericNumber(CoordinatorEntity, NumberEntity):
             'bat_low_to_uti': 'mdi:battery-alert',
             'ac_to_bat_volt': 'mdi:battery-charging',
             'vpp_export_limit_power_rate': 'mdi:transmission-tower-export',
+            'load_first_battery_minimum_soc': 'mdi:battery-sync',
         }
         return icon_map.get(control_name, 'mdi:tune')
 

--- a/custom_components/growatt_modbus/profiles/sph.py
+++ b/custom_components/growatt_modbus/profiles/sph.py
@@ -71,6 +71,14 @@ SPH_3000_6000 = {
         0: {'name': 'on_off', 'scale': 1, 'unit': '', 'access': 'RW', 'desc': '0=Off, 1=On'},
         3: {'name': 'active_power_rate', 'scale': 1, 'unit': '%', 'access': 'RW'},
 
+        # Load First Battery Minimum SOC
+        # Not in official Growatt Modbus protocol documentation.
+        # Source: https://www.photovoltaikforum.com/thread/192228-growatt-sph-modbus-rtu-rj45-pinout-und-register-beschreibung/?postID=3017838#post3017838
+        # Also confirmed by homeassistant-solax-modbus plugin_growatt.py (register 608, GEN3/SPH).
+        608: {'name': 'load_first_battery_minimum_soc', 'scale': 1, 'unit': '%', 'access': 'RW',
+              'valid_range': (10, 100),
+              'desc': 'Minimum battery SOC in Load First mode — inverter stops discharging below this level (10-100%)'},
+
         # Battery Management Control (1000+ range)
         1044: {'name': 'priority_mode', 'scale': 1, 'unit': '', 'access': 'RW',
                'desc': 'Priority mode selection',
@@ -249,6 +257,14 @@ SPH_7000_10000 = {
         # Basic Control
         0: {'name': 'on_off', 'scale': 1, 'unit': '', 'access': 'RW', 'desc': '0=Off, 1=On'},
         3: {'name': 'active_power_rate', 'scale': 1, 'unit': '%', 'access': 'RW'},
+
+        # Load First Battery Minimum SOC
+        # Not in official Growatt Modbus protocol documentation.
+        # Source: https://www.photovoltaikforum.com/thread/192228-growatt-sph-modbus-rtu-rj45-pinout-und-register-beschreibung/?postID=3017838#post3017838
+        # Also confirmed by homeassistant-solax-modbus plugin_growatt.py (register 608, GEN3/SPH).
+        608: {'name': 'load_first_battery_minimum_soc', 'scale': 1, 'unit': '%', 'access': 'RW',
+              'valid_range': (10, 100),
+              'desc': 'Minimum battery SOC in Load First mode — inverter stops discharging below this level (10-100%)'},
 
         # Battery Management Control (1000+ range)
         1044: {'name': 'priority_mode', 'scale': 1, 'unit': '', 'access': 'RW',


### PR DESCRIPTION
### Summary

Adds a writable number (slider) entity — **Load First Battery Minimum SOC** — to all SPH hybrid inverter profiles. This sets the minimum battery SOC the inverter will discharge to when operating in **Load First** mode.

### What changed

**`profiles/sph.py`**
Added holding register 608 (`load_first_battery_minimum_soc`) to the `holding_registers` dict of:
- `SPH_3000_6000`
- `SPH_7000_10000`

The V2.01 variants (`SPH_3000_6000_V201`, `SPH_7000_10000_V201`) inherit it automatically via the existing `**SPH_xxxx['holding_registers']` spread.

**`const.py`**
- Added `load_first_battery_minimum_soc` entry to `WRITABLE_REGISTERS` (register 608, range 10–100 %, scale 1)
- Added `load_first_battery_minimum_soc` to `SENSOR_DEVICE_MAP[DEVICE_TYPE_BATTERY]` so the entity appears under the Battery device

**`growatt_modbus.py`**
- Added `load_first_battery_minimum_soc: int = 10` field to the `GrowattData` dataclass (required for `native_value` reads in `GrowattGenericNumber`)
- Added a read block in `_read_device_info()` guarded by `if 608 in holding_map:`, matching the same pattern used for all other SPH control registers

**`number.py`**
- Added a friendly name override (`"Load First Battery Minimum SOC"`) in `GrowattGenericNumber`
- Added icon mapping (`"mdi:battery-sync"`) matching the equivalent entity in homeassistant-solax-modbus

### Register source

Register 608 is not documented in the official Growatt Modbus RTU Protocol V1.39. It was identified from:
- Community research: https://www.photovoltaikforum.com/thread/192228-growatt-sph-modbus-rtu-rj45-pinout-und-register-beschreibung/?postID=3017838#post3017838
- Cross-validated against the homeassistant-solax-modbus integration (`plugin_growatt.py`, `GEN3 | HYBRID` allowedtypes, register 608)

### Testing

- [x] Confirmed working on a real SPH inverter "Growatt SPH 8000TL3 BH-UP"
- [x] Entity appears in HA under the Battery device with correct name and icon
- [x] `native_value` reads back the current inverter value correctly
- [x] Slider writes are accepted by the inverter and survive coordinator refresh (read-back verified)


### Models affected

`SPH_3000_6000`, `SPH_7000_10000`, `SPH_3000_6000_V201`, `SPH_7000_10000_V201`

`SPH_8000_10000_HU` is intentionally excluded — register 608 has not been validated on HU hardware.
