### PR TITLE
v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Growatt Modbus Integration for Home Assistant ☀️
 
 ![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange.svg)
-![Version](https://img.shields.io/badge/Version-0.6.9-blue.svg)
+![Version](https://img.shields.io/badge/Version-0.7.0-blue.svg)
 [![GitHub Issues](https://img.shields.io/github/issues/0xAHA/Growatt_ModbusTCP.svg)](https://github.com/0xAHA/Growatt_ModbusTCP/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/0xAHA/Growatt_ModbusTCP.svg?style=social)](https://github.com/0xAHA/Growatt_ModbusTCP)
 
@@ -295,12 +295,14 @@ The integration pre-configures sensors with the correct `state_class` and `devic
 
 See **[RELEASENOTES.md](RELEASENOTES.md)** for the full changelog.
 
-**v0.6.9 highlights:**
+**v0.7.0 highlights:**
 
+- **SPH TL3 — Energy Today drop at sunset fixed (#225):** Per-MPPT energy registers are now used as long as any string has accumulated energy today, regardless of whether PV strings are currently producing. Previously the data source switched to register 54 (AC output total) at sunset, causing a visible ~2 kWh drop.
+- **WIT 8K-HU — Battery voltage wrong value fixed (#247):** VPP register 31214 (`maps_to battery_voltage`) reports spuriously low values on some firmware variants. The integration now reads all available voltage registers and selects the highest plausible value, consistent with the existing battery current selection strategy.
 - **SPF — Battery Power always zero fixed (#174):** `_validate_spf_battery_power_sign` referenced a non-existent attribute (`data.inverter_status` instead of `data.status`), silently suppressing battery power on every poll.
-- **MID — Grid and load energy sensors added (#240):** Power flow (import/export/load) and daily/total energy counters were missing from the profile despite the hardware responding at registers 3041–3078. `grid_energy_today` now reads directly from hardware instead of a broken calculation.
-- **MID V2.01 — Battery support added (#240):** Full battery sensor set (voltage, SOC, current, temperature, SOH, power, charge/discharge energy) added via VPP 31200+ registers, confirmed live in register scan.
-- **SPH / TL-XH — Accurate lifetime PV generation (#243):** Registers 91/92 (`Epv_total H/L`) added to SPH and TL-XH profiles. This is the raw DC-side cumulative generation shown in ShinePhone as "Total Power Generation" — more reliable for the HA energy dashboard than the previously used net-calculated `energy_total`.
+- **MID — Grid, load energy and battery sensors added (#240):** Power flow, daily/total energy counters, and full VPP battery set (voltage, SOC, current, temp, SOH, power) were all missing from the profile.
+- **SPH / TL-XH — Accurate lifetime PV generation (#243):** Registers 91/92 (`Epv_total H/L`) added — raw DC-side cumulative generation, matching ShinePhone "Total Power Generation".
+- **SPE auto-detection fixed (#212):** DTC 64541 now maps correctly to the SPE 8000-12000 ES profile instead of falling back to SPH 7-10kW.
 
 **v0.6.8 highlights:**
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,73 +4,67 @@
 
 ---
 
-## v0.6.9
+## v0.7.0
 
-Issues: #174 · #131 · #240 · #243
+Issues: #174 · #131 · #212 · #225 · #240 · #243 · #244 · #247
 
 ---
 
 ### Fixes
 
+- **SPH TL3 — Energy Today drop at sunset fixed (#225):** Per-MPPT energy registers
+  (`pv1/2/3_energy_today`) are now used whenever any string has accumulated energy today,
+  regardless of whether PV voltage/power is currently non-zero. Previously the data source
+  switched to register 54 (AC output total, which includes battery discharge) at the moment
+  PV production stopped, causing a visible drop of ~2 kWh at end of day. The per-MPPT sum
+  is now held through the night and cleared at dawn when the inverter resets its registers.
+
+- **WIT 8K-HU — Battery voltage wrong value fixed (#247):** VPP register 31214
+  (`battery_voltage_vpp`, mapped to `battery_voltage`) reports a spuriously low value
+  (e.g. 5.2 V) on some WIT firmware variants while the native register 8034 carries the
+  correct reading (53.7 V). The integration now applies the same multi-candidate
+  selection strategy already used for battery current: all available voltage registers are
+  read, values outside the plausible range (10–800 V) are discarded, and the highest
+  remaining candidate is selected. This resolves the secondary symptom too — battery power
+  scale auto-detection was failing because V×I ≈ 1 W never exceeded the 50 W threshold.
+
 - **SPF — Battery Power always zero fixed (#174):** The `_validate_spf_battery_power_sign`
-  function (introduced to correct intermittent sign errors during PV charging) referenced
-  `data.inverter_status`, which does not exist as a `GrowattData` field. The correct field is
-  `data.status`. The resulting `AttributeError` was silently caught by the battery data
-  exception handler, preventing `charge_power` and `discharge_power` from ever being assigned
-  — leaving `battery_power` permanently at 0W regardless of actual activity.
+  function referenced `data.inverter_status`, which does not exist as a `GrowattData` field.
+  The correct field is `data.status`. The `AttributeError` was silently caught by the battery
+  data exception handler, leaving `battery_power` permanently at 0W.
 
-### MID Series — New Sensors (#240)
+- **SPH Hybrid — Load First Battery Minimum SOC display bugfix (#244):** Corrected reading
+  and display of the Load First SOC value introduced in v0.6.8.
 
-The MID profile was missing a large block of registers that the hardware has responded to all
-along. The following sensors are now available on MID (both legacy and V2.01 variants):
+### New Sensors & Profile Updates
 
-- **Grid power flow:** `power_to_grid`, `power_to_user`, `power_to_load` (registers 3041–3046)
-- **Grid energy counters:** `energy_to_grid_today`, `energy_to_grid_total`,
-  `energy_to_user_today`, `energy_to_user_total` (registers 3067–3074)
-- **Load energy counters:** `load_energy_today`, `load_energy_total` (registers 3075–3078)
-- **VPP load power fallback:** register 31118/31119 added to V2.01 profile
+- **MID Series — Grid, load energy and battery sensors (#240):** The MID profile was missing
+  a large block of registers that the hardware responds to. Now available on both legacy and
+  V2.01 variants:
+  - **Grid power flow:** `power_to_grid`, `power_to_user`, `power_to_load` (regs 3041–3046)
+  - **Grid energy counters:** `energy_to_grid_today/total`, `energy_to_user_today/total`
+    (regs 3067–3074)
+  - **Load energy counters:** `load_energy_today`, `load_energy_total` (regs 3075–3078)
+  - `grid_energy_today` now reads directly from register 3071/3072 instead of a calculation
+    that collapsed to zero when load energy was unavailable
+  - V2.01 profile gains full battery support (31200+ VPP range, confirmed responding):
+    voltage (31214, 404.8 V confirmed), SOC (31217), current (31215/31216), temperature
+    (31222/31223), SOH (31218), power (31200/31201), charge/discharge energy (31202–31209)
+  - `has_battery` is now `True` for `mid_15000_25000tl3_x_v201`
 
-As a result `grid_energy_today` now reads directly from hardware (registers 3071/3072) rather
-than being estimated from a calculation that collapsed to zero when load energy was unavailable.
+- **SPH / TL-XH — Accurate lifetime PV generation (#243):** Registers 91/92
+  (`Epv_total H/L`, Growatt V1.39 protocol) added to SPH and TL-XH profiles. This is the
+  raw DC-side cumulative generation shown in ShinePhone as "Total Power Generation" and is
+  more reliable for the HA energy dashboard than `energy_total` (regs 55/56), which is a
+  net calculated value that can drift with battery cycling. MOD, WIT, and SPH-TL3 already
+  had these registers; MIC and SPF use 91/92 for other purposes and are unchanged.
 
-The V2.01 profile additionally gains full battery support via the 31200+ VPP range (confirmed
-responding in issue #240 scan):
+- **SPH — Export Limit Registers Added (#131):** Holding registers 122 (`export_limit_mode`,
+  0=Disabled/1=RS485) and 123 (`export_limit_power`, ×0.1 %) were missing from SPH 3-6kW
+  and 7-10kW profiles. Now defined in both base profiles and inherited by all V2.01 variants.
 
-- **Battery voltage** (31214, 404.8V confirmed), **Battery SOC** (31217), **Battery current**
-  (31215/31216), **Battery temperature** (31222/31223), **Battery SOH** (31218),
-  **Battery power** (31200/31201), **charge/discharge energy** (31202–31209)
-
-`has_battery` is now `True` for `mid_15000_25000tl3_x_v201`.
-
-### PV Energy Total — Accurate Lifetime Generation (#243)
-
-Registers 91/92 (`Epv_total H/L` per Growatt V1.39 protocol) contain the raw DC-side
-cumulative generation from the PV array. This is the value shown as "Total Power Generation"
-in ShinePhone and is the correct source for the HA energy dashboard.
-
-The previously used `energy_total` (registers 55/56) is a net calculated value that can drift
-with battery cycling, making it unreliable as a long-term energy counter.
-
-Registers 91/92 (`pv_energy_total`) have been added to the **SPH** and **TL-XH** profiles.
-The coordinator already preferred `pv_energy_total` over `energy_total` when the former was
-non-zero — these profiles now populate that field from hardware rather than leaving it at 0.
-
-- **SPH** (all variants): registers 91/92 added
-- **TL-XH** (all variants): registers 91/92 added
-- **MOD, WIT, SPH-TL3:** already had 91/92 in prior releases
-- **MIC, SPF:** registers 91/92 serve different purposes on these models and are unchanged
-
-### SPH — Export Limit Registers Added (#131)
-
-Holding registers 122 (`export_limit_mode`) and 123 (`export_limit_power`) were missing from
-both SPH 3-6kW and 7-10kW profiles despite being documented in the official Growatt Modbus
-protocol (register 122 = RS485 export limit mode, register 123 = limit percentage × 0.1).
-
-These are now defined in both base profiles and inherited by all V2.01 variants. This does not
-resolve the RA1.0 firmware register aliasing reported in #131 — that is a separate issue
-affecting the 1017-1088 holding range only.
-- **SPH Hybrid — Load First Battery Minimum SOC control - bugfix:**
-  Fixing bug with reading and showing new Load First SOC value.
+- **SPE auto-detection fixed (#212):** DTC code 64541 is now mapped to `spe_8000_12000_es`.
+  Previously the integration fell through to SPH 7-10kW on first setup.
 
 ---
 

--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -1301,25 +1301,21 @@ class GrowattModbus:
             # Energy Today
             # For WIT/MIC/SPH-TL3 with per-MPPT tracking: use sum of PV string energy for accurate solar production
             # Registers 53-54 show total system AC output (PV+battery), not PV-only (Issue #146)
-            # IMPORTANT: Only use per-MPPT calculation if PV strings are actually connected (avoid garbage data)
-            pv1_connected = data.pv1_voltage > 0 or data.pv1_power > 0
-            pv2_connected = data.pv2_voltage > 0 or data.pv2_power > 0
-            pv3_connected = data.pv3_voltage > 0 or data.pv3_power > 0
+            # Use per-MPPT values whenever any register has a non-zero accumulated value.
+            # Do NOT gate on pv*_connected (voltage/power > 0): at sunset those drop to 0 but the
+            # per-MPPT energy registers still hold today's accumulated total. Gating on connected
+            # caused a data-source switch at end of day, producing a spurious drop (Issue #225).
+            # Each string contributes only if its own energy_today > 0, so a 2-string model with
+            # pv3_energy_today = 0 all day is handled correctly without the connected check.
+            has_mppt_energy = (data.pv1_energy_today > 0 or data.pv2_energy_today > 0 or data.pv3_energy_today > 0)
 
-            if (pv1_connected or pv2_connected or pv3_connected) and (data.pv1_energy_today > 0 or data.pv2_energy_today > 0 or data.pv3_energy_today > 0):
-                # Calculate energy only from connected strings to avoid garbage data
-                pv_energy_sum = 0.0
-                if pv1_connected and data.pv1_energy_today > 0:
-                    pv_energy_sum += data.pv1_energy_today
-                if pv2_connected and data.pv2_energy_today > 0:
-                    pv_energy_sum += data.pv2_energy_today
-                if pv3_connected and data.pv3_energy_today > 0:
-                    pv_energy_sum += data.pv3_energy_today
+            if has_mppt_energy:
+                pv_energy_sum = data.pv1_energy_today + data.pv2_energy_today + data.pv3_energy_today
 
                 # Sanity check: per-MPPT energy should be reasonable (< 100 kWh per day for MIC/small inverters)
                 if pv_energy_sum < 100:
                     data.energy_today = pv_energy_sum
-                    logger.debug(f"[{self.register_map['name']}@{self.connection_id}] Energy today from connected MPPTs: PV1={data.pv1_energy_today if pv1_connected else 'N/A'} + PV2={data.pv2_energy_today if pv2_connected else 'N/A'} + PV3={data.pv3_energy_today if pv3_connected else 'N/A'} = {data.energy_today} kWh")
+                    logger.debug(f"[{self.register_map['name']}@{self.connection_id}] Energy today from per-MPPT registers: PV1={data.pv1_energy_today} + PV2={data.pv2_energy_today} + PV3={data.pv3_energy_today} = {data.energy_today} kWh")
                 else:
                     # Garbage data detected - fall back to register reading
                     logger.warning(f"[{self.register_map['name']}@{self.connection_id}] Per-MPPT energy {pv_energy_sum} kWh unrealistic - using fallback register instead")
@@ -1328,7 +1324,7 @@ class GrowattModbus:
                         data.energy_today = self._get_register_value(energy_today_addr) or 0.0
                         logger.debug(f"[{self.register_map['name']}@{self.connection_id}] Energy today from reg {energy_today_addr}: {data.energy_today} kWh")
             else:
-                # Fallback to total system output for other inverters
+                # No per-MPPT data (profile doesn't define those registers, or midnight register reset)
                 energy_today_addr = self._find_register_by_name('energy_today_low')
                 if energy_today_addr:
                     data.energy_today = self._get_register_value(energy_today_addr) or 0.0
@@ -1991,12 +1987,40 @@ class GrowattModbus:
     def _read_battery_data(self, data: GrowattData) -> None:
         """Read battery data (storage/hybrid models)"""
         try:
-            # Battery voltage (use smart fallback if multiple ranges available)
-            value = self._get_register_value_with_fallback('battery_voltage')
-            if value is not None:
-                data.battery_voltage = value
+            # Battery voltage
+            # Issue #247: on some WIT firmware variants, VPP register 31214 (maps_to='battery_voltage')
+            # reports a spuriously low value (e.g. 5.2 V) while the native 8034 register is correct
+            # (53.7 V). Apply the same multi-candidate / largest-plausible-value strategy used for
+            # battery_current: read all available voltage registers, discard implausibly low values,
+            # and pick the highest (most likely correct) reading.
+            _VOLTAGE_LOOKUP_NAMES = (
+                'battery_voltage',       # native 8000-range or VPP maps_to (e.g. WIT 8034 / 31214)
+                'battery_voltage_bms',   # BMS voltage (WIT-only, typically more accurate)
+                'battery_voltage_legacy',
+            )
+            _VOLTAGE_MIN_V = 10.0   # below this is implausible for any connected battery pack
+            _VOLTAGE_MAX_V = 800.0  # sanity ceiling
+
+            seen_voltage_addrs: set = set()
+            voltage_candidates: list = []
+            for _vname in _VOLTAGE_LOOKUP_NAMES:
+                _a = (self._find_register_by_name_with_fallback(_vname) or
+                      self._find_register_by_name(_vname))
+                if _a and _a not in seen_voltage_addrs:
+                    seen_voltage_addrs.add(_a)
+                    _v = self._get_register_value(_a)
+                    if _v is not None and _VOLTAGE_MIN_V <= _v <= _VOLTAGE_MAX_V:
+                        voltage_candidates.append((_a, _v))
+                        logger.debug(f"Battery voltage candidate reg {_a} ({_vname}): {_v}V")
+
+            if voltage_candidates:
+                _best_addr, _best_val = max(voltage_candidates, key=lambda c: c[1])
+                data.battery_voltage = _best_val
+                logger.debug(f"Battery voltage: {_best_val}V (selected from {len(voltage_candidates)} candidate(s), reg {_best_addr})")
             else:
-                data.battery_voltage = 0.0
+                # All candidates out of range or absent — fall back to smart-fallback lookup
+                value = self._get_register_value_with_fallback('battery_voltage')
+                data.battery_voltage = value if value is not None else 0.0
 
             # Battery current (signed: positive=discharge, negative=charge)
             # Issue #226: some WIT firmware returns a small wrong non-zero on VPP reg 31215

--- a/custom_components/growatt_modbus/manifest.json
+++ b/custom_components/growatt_modbus/manifest.json
@@ -12,5 +12,5 @@
     "pymodbus>=3.0.0",
     "pyserial>=3.4"
   ],
-  "version": "0.6.9"
+  "version": "0.7.0"
 }


### PR DESCRIPTION
Release Notes

<a href="https://www.buymeacoffee.com/0xAHA" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>

---

## v0.7.0

Issues: #247

---

### Fixes

- **WIT 8K-HU — Battery voltage wrong value fixed (#247):** VPP register 31214
  (`battery_voltage_vpp`, mapped to `battery_voltage`) reports a spuriously low value
  (e.g. 5.2 V) on some WIT firmware variants while the native register 8034 carries the
  correct reading (53.7 V). The integration now applies the same multi-candidate
  selection strategy already used for battery current: all available voltage registers are
  read, values outside the plausible range (10–800 V) are discarded, and the highest
  remaining candidate is selected. This resolves the secondary symptom too — battery power
  scale auto-detection was failing because V×I ≈ 1 W never exceeded the 50 W threshold.
