### PR TITLE
v0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Growatt Modbus Integration for Home Assistant ☀️
 
 ![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange.svg)
-![Version](https://img.shields.io/badge/Version-0.7.0-blue.svg)
+![Version](https://img.shields.io/badge/Version-0.7.1-blue.svg)
 [![GitHub Issues](https://img.shields.io/github/issues/0xAHA/Growatt_ModbusTCP.svg)](https://github.com/0xAHA/Growatt_ModbusTCP/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/0xAHA/Growatt_ModbusTCP.svg?style=social)](https://github.com/0xAHA/Growatt_ModbusTCP)
 
@@ -96,6 +96,7 @@ Understanding which sensor measures what is the most common source of confusion.
 | **SPH** 3–6kW         | Hybrid    | Single | Yes     | VPP + Legacy | ✅     |
 | **SPH** 7–10kW        | Hybrid    | Single | Yes     | VPP + Legacy | ✅     |
 | **SPH/SPM** 8–10kW HU | Hybrid    | Single | Yes     | VPP + Legacy | ⚠️   |
+| **SPA** 3–6kW TL BL   | AC Storage | Single | Yes    | Auto         | ✅     |
 | **SPH-TL3** 3–10kW    | Hybrid    | Three  | Yes     | VPP + Legacy | ✅     |
 | **WIT** 4–15kW TL3    | Hybrid    | Three  | Yes     | VPP v2.02    | ✅     |
 
@@ -294,6 +295,11 @@ The integration pre-configures sensors with the correct `state_class` and `devic
 ## What's New
 
 See **[RELEASENOTES.md](RELEASENOTES.md)** for the full changelog.
+
+**v0.7.1 highlights:**
+
+- **SPA series — new profile (#249):** SPA 3000–6000TL BL (AC-coupled battery storage, no PV inputs) now auto-detects correctly and gets its own dedicated profile. All battery, energy breakdown, load power, and AC voltage sensors work. Previously auto-detected as MIN 7000-10000TL-X with all sensors at zero.
+- **MIC misclassification of legacy string inverters fixed (#242):** Inverters with high PV voltage (> 80 V) and no 3000+ register range no longer incorrectly detect as MIC micro inverters.
 
 **v0.7.0 highlights:**
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,91 @@
 
 ---
 
+## v0.7.1
+
+Issues: #249 · #242 · #212
+
+---
+
+### New Profiles
+
+- **SPA series — new profile (#249):** The SPA 3000–6000TL BL (AC-coupled battery storage,
+  no PV MPPT inputs) now has a dedicated profile. Previously it auto-detected as
+  MIN 7000-10000TL-X and all sensors read zero; with SPH-TL3 manually selected, AC voltage,
+  frequency, and load power also read zero because the SPA never populates the 0-124
+  register range. The new `spa_3000_6000_tl_bl` profile reads exclusively from the
+  1000-1124 range where the SPA keeps all its data. Load power is correctly sourced from
+  registers 1037/1038 (SPH-TL3 uses 1021/1022 for this, which are zero on the SPA).
+  Confirmed sensors: battery voltage/SOC/temp/type, charge/discharge power, power to grid,
+  load power, AC voltage (~216V at reg 1105), and the full energy breakdown set
+  (energy to user/grid today/total, battery charge/discharge today/total, load energy
+  today/total). Holding register layout (battery management, TOU time periods) is identical
+  to SPH-TL3.
+
+### Universal Register Scanner — Device Selector
+
+The Universal Register Scanner service now has a **Device** dropdown at the top of the service
+form. Selecting your configured inverter pre-fills all connection details (IP, port, serial path,
+baudrate, slave ID) and guarantees that the "CURRENTLY CONFIGURED PROFILE" and "CURRENT ENTITY
+VALUES" sections appear in the CSV output. Previously, entity values were only included when the
+scanner could match the connection parameters you typed against a running integration entry, which
+silently failed for serial connections if the device path differed even slightly. Manual IP/serial
+entry fields are still available for scanning a new inverter before it has been added to the
+integration.
+
+### Bug Fixes
+
+- **WIT 8K-HU — Battery voltage/current fix (take 2) (#247):** The v0.7.0 multi-candidate
+  selection was not actually comparing the VPP register (31214, spurious 5.2V) against the
+  native register (8034, correct 53.7V). The candidate loop used
+  `_find_register_by_name_with_fallback()` which filters down to a single address based on
+  the detected preferred range — so when the VPP range scored non-zero (because 31214 returns
+  a wrong-but-non-zero value), only reg 31214 was ever evaluated as a candidate and reg 8034
+  was never read. Fixed by replacing the single-address lookup with
+  `_find_all_registers_by_name()` so every matching address across all ranges is evaluated.
+  The 5.2V value at reg 31214 is then correctly discarded by the 10V plausibility floor and
+  the 53.7V from reg 8034 is selected. The same fix is applied to battery current.
+
+### Profile Fixes
+
+- **SPE 8000-12000 ES — register map corrected (#212):** The SPE profile previously inherited
+  the SPF register map wholesale. Cross-analysis of the Issue #212 daytime scan against actual
+  entity values (from the accompanying XLSX file) revealed several incorrect mappings:
+  - Registers 36/37 (`ac_input_power`) produce a 429 GW overflow on SPE — the value is a
+    signed 32-bit grid power register that the coordinator interprets as unsigned. These
+    registers have been removed from the profile until correct signed semantics are confirmed.
+  - Registers 64/65 (SPF: "AC discharge energy today") are **grid import energy today** on SPE.
+    Confirmed: 20.0 kWh scan value vs 19.8 kWh actual ✓
+  - Registers 66/67 (SPF: "AC discharge energy total") are **grid import energy total** on SPE.
+    Confirmed: 855.2 kWh ✓
+  - Registers 85/86 (SPF: "operational discharge energy today") are **load energy today** on SPE.
+    Confirmed: 21.3 kWh vs 20.9 kWh actual ✓
+  - Registers 87/88 (SPF: "operational discharge energy total") are **load energy total** on SPE.
+    Confirmed: 1028.3 kWh vs 1027.9 kWh actual ✓
+  - Registers 92–97 (generator discharge/power/voltage) removed — SPE has no generator input.
+  All confirmed registers (battery voltage 50.12 V, grid voltage 235.8 V, PV1/PV2 voltage/power,
+  temperatures, fan speeds, charge/discharge energy totals) remain correctly inherited from SPF.
+
+### Auto-Detection Fixes
+
+- **SPA auto-detection (#249):** SPA responds to all register ranges with zeros rather than
+  exceptions, causing it to fall through into the MIN detection branch. Detection now checks
+  register 1013 (battery voltage, always ~530 raw = 53 V on SPA) combined with register 38
+  (AC voltage in base range, always 0 on SPA). This check runs before the MIN series check.
+  SPH-TL3 is not affected — it always has register 38 > 0 (grid voltage present even at
+  night). SPH 3-6kW is not affected — its battery voltage is at register 13, not 1013.
+
+- **MIC misclassification of legacy string inverters fixed (#242):** Inverters using the
+  legacy 0-124 register range but lacking the 3000+ range were incorrectly detected as MIC
+  micro inverters if their PV voltage happened to be non-zero at register 3. MIC micro
+  inverters operate at low panel voltages (< 80 V raw). The detection now checks: if reg 3
+  raw > 800 (> 80 V) and the 3000+ range is absent, the device is a legacy string inverter,
+  not a MIC. It falls back to `min_7000_10000_tl_x` as the closest approximation and logs a
+  warning. A dedicated legacy profile for this firmware class (DM1.0, ~11 kW, 3 strings,
+  0-124 range only) is planned pending further scan data and model confirmation.
+
+---
+
 ## v0.7.0
 
 Issues: #174 · #131 · #212 · #225 · #240 · #243 · #244 · #247

--- a/custom_components/growatt_modbus/auto_detection.py
+++ b/custom_components/growatt_modbus/auto_detection.py
@@ -430,9 +430,21 @@ def detect_profile_from_dtc(dtc_code: int) -> Optional[str]:
         # SPH series - Official Growatt DTCs
         3501: 'sph_3000_6000_v201',       # SPH 3000-6000TL BL (legacy/pre-UP, may need protocol check)
         3502: 'sph_3000_6000_v201',       # SPH 3000-6000TL BL -UP (upgraded model)
-        3735: 'sph_3000_6000_v201',       # SPA 3000-6000TL BL (similar to SPH)
-        3601: 'sph_tl3_3000_10000_v201',  # SPH 4000-10000TL3 BH-UP
-        3725: 'sph_tl3_3000_10000_v201',  # SPA 4000-10000TL3 BH-UP
+        3735: 'sph_3000_6000_v201',       # SPA 3000-6000TL BL (VPP-capable variant, confirmed DTC)
+        # TODO #249: DTC 3735 maps to sph_3000_6000_v201 (VPP-capable SPA variant with full
+        # 31000+ register support). The non-VPP SPA (firmware RH1.0) is detected via
+        # async_detect_inverter_series() battery/AC voltage check before DTC lookup,
+        # so it never reaches this map. If a user has firmware that reports DTC 3735 AND
+        # supports VPP, sph_3000_6000_v201 is correct. Consider a dedicated
+        # spa_3000_6000_tl_bl_v201 once VPP register layout is confirmed for SPA.
+        #
+        # VPP Register Applicability Notes for SPA/SPH DTC family (from Growatt VPP 2.01/2.03 docs):
+        #   30406 (Load Priority Discharge Cutoff SOC): Only DTC 3502, 3735, 3750, 3601
+        #   30208 (Export Limitation Protection Mode): NOT used by DTC 3725, 3601, 5601, 5800
+        #   30157 (EPS Offline Voltage): Different valid ranges per model —
+        #     consult Growatt documentation for per-model min/max before writing
+        3601: 'sph_tl3_3000_10000_v201',  # SPH 4000-10000TL3 BH-UP (confirmed DTC)
+        3725: 'sph_tl3_3000_10000_v201',  # SPA 4000-10000TL3 BH-UP (confirmed DTC)
 
         # SPF series - Off-Grid (034xx range from SPF protocol documentation)
         3400: 'spf_3000_6000_es_plus',         # SPF 3000-6000 ES PLUS (off-grid)
@@ -537,10 +549,43 @@ async def async_detect_inverter_series(
                 client.read_input_registers, 3003, 1
             )
             if min_range_test is None:
-                # Has 0-179 range but NOT 3000 range = MIC series
+                # Has 0-179 range but NOT 3000 range.
+                # Guard: MIC micro inverters have PV voltage < ~80V (raw < 800).
+                # A raw value > 800 at reg 3 indicates a legacy string inverter
+                # (e.g. MID DM1.0 firmware with 3-string, ~600V PV) that happens
+                # to lack the 3000+ range — not a MIC micro inverter.
+                if mic_test[0] > 800:
+                    _LOGGER.info(
+                        f"PV voltage {mic_test[0] * 0.1:.1f}V at reg 3 too high for MIC "
+                        f"(raw={mic_test[0]}, threshold=800) — likely legacy string inverter. "
+                        f"Defaulting to min_7000_10000_tl_x as closest approximation."
+                    )
+                    await hass.async_add_executor_job(client.disconnect)
+                    return 'min_7000_10000_tl_x'
                 _LOGGER.debug("Detected 0-179 range without 3000 range - MIC micro inverter")
                 await hass.async_add_executor_job(client.disconnect)
                 return 'mic_600_3300tl_x'
+
+        # CHECK SPA SERIES (pure AC-coupled storage, no PV inputs) — BEFORE MIN
+        # SPA responds to ALL register ranges with zeros (not exceptions), which fools the MIN
+        # detection. The distinguishing test is battery voltage at reg 1013 (always populated
+        # on SPA, ~530 raw = 53V) combined with no AC voltage at reg 38 (SPA never populates
+        # the 0-124 base range). SPH-TL3 always has reg 38 > 0 (grid voltage, even at night).
+        # SPH 3-6kW has battery at reg 13, not 1013, so reg 1013 = 0 on SPH 3-6kW.
+        spa_battery_test = await hass.async_add_executor_job(
+            client.read_input_registers, 1013, 1
+        )
+        if spa_battery_test is not None and len(spa_battery_test) > 0 and spa_battery_test[0] > 100:
+            base_ac_test = await hass.async_add_executor_job(
+                client.read_input_registers, 38, 1
+            )
+            if base_ac_test is None or len(base_ac_test) == 0 or base_ac_test[0] == 0:
+                _LOGGER.info(
+                    f"Detected SPA series: battery voltage at reg 1013 = {spa_battery_test[0] * 0.1:.1f}V "
+                    f"(raw={spa_battery_test[0]}), no AC voltage in base range (reg 38 = 0)"
+                )
+                await hass.async_add_executor_job(client.disconnect)
+                return 'spa_3000_6000_tl_bl'
 
         # CHECK MIN SERIES (uses 3000 range)
         # Test for PV1 at register 3003 to confirm MIN series

--- a/custom_components/growatt_modbus/device_profiles.py
+++ b/custom_components/growatt_modbus/device_profiles.py
@@ -611,6 +611,28 @@ INVERTER_PROFILES = {
     },
 
     # ========================================================================
+    # SPA SERIES - AC-Coupled Battery Storage (No PV MPPT)
+    # ========================================================================
+
+    "spa_3000_6000_tl_bl": {
+        "name": "SPA (AC Storage) 3-6kW",
+        "description": "AC-coupled battery storage inverter, no solar DC inputs (SPA 3000TL BL)",
+        "register_map": "SPA_3000_6000_TL_BL",
+        "phases": 1,
+        "has_pv3": False,
+        "has_battery": True,
+        "max_power_kw": 6.0,
+        "sensors": (
+            BASIC_AC_SENSORS |
+            GRID_SENSORS |
+            POWER_FLOW_SENSORS |
+            ENERGY_BREAKDOWN_SENSORS |
+            BATTERY_SENSORS |
+            STATUS_SENSORS
+        ),
+    },
+
+    # ========================================================================
     # SPF SERIES - Off-Grid Storage (Battery with AC Input/Output)
     # ========================================================================
 
@@ -646,11 +668,26 @@ INVERTER_PROFILES = {
             BASIC_PV_SENSORS |
             BASIC_AC_SENSORS |
             ENERGY_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
+            ENERGY_BREAKDOWN_SENSORS |   # includes load_energy_today/total (regs 85-88)
+            BATTERY_SENSORS |            # includes ac_discharge_energy_total (reg 66/67 = grid import total)
             TEMPERATURE_SENSORS |
             STATUS_SENSORS |
-            SPF_OFFGRID_SENSORS
+            {
+                # SPF-compatible sensors confirmed working on SPE
+                "load_percentage",        # reg 27
+                "ac_apparent_power",      # regs 11/12
+                "grid_voltage",           # reg 20
+                "grid_frequency",         # reg 21
+                "ac_discharge_energy_today",  # regs 64/65 = grid import today on SPE
+                "mppt_fan_speed",         # reg 81
+                "inverter_fan_speed",     # reg 82
+                "dcdc_temp",              # reg 26
+                "buck1_temp",             # reg 32
+                "buck2_temp",             # reg 33
+                # ac_input_power excluded — regs 36/37 produce 429GW overflow on SPE
+                # generator_* excluded — SPE has no generator input
+                # op_discharge_energy_today/total excluded — remapped to load_energy_* in profile
+            }
         ),
     },
 

--- a/custom_components/growatt_modbus/diagnostic.py
+++ b/custom_components/growatt_modbus/diagnostic.py
@@ -95,18 +95,24 @@ OFFGRID_SCAN_RANGES = [
 # Service schema
 SERVICE_EXPORT_DUMP_SCHEMA = vol.Schema(
     {
-        # Connection type selection
+        # Optional: select a configured integration entry to pre-fill connection details.
+        # When provided, connection_type/host/port/device/baudrate/slave_id are all ignored —
+        # they are read directly from the config entry. Profile and entity values are always
+        # included. When omitted, manual connection parameters below are required.
+        vol.Optional("config_entry"): cv.string,
+
+        # Connection type selection (ignored when config_entry is set)
         vol.Optional("connection_type", default="tcp"): vol.In(["tcp", "serial"]),
 
-        # TCP parameters (required if connection_type=tcp)
+        # TCP parameters (required if connection_type=tcp and no config_entry)
         vol.Optional("host"): cv.string,
         vol.Optional("port", default=502): cv.port,
 
-        # Serial parameters (required if connection_type=serial)
+        # Serial parameters (required if connection_type=serial and no config_entry)
         vol.Optional("device"): cv.string,  # e.g., /dev/ttyUSB0, COM3
         vol.Optional("baudrate", default=9600): vol.All(vol.Coerce(int), vol.In([4800, 9600, 19200, 38400, 57600, 115200])),
 
-        # Common parameters
+        # Common parameters (ignored when config_entry is set — slave_id read from entry)
         vol.Optional("slave_id", default=1): vol.All(vol.Coerce(int), vol.Range(min=1, max=247)),
         vol.Optional("notify", default=True): cv.boolean,
         vol.Optional("offgrid_mode", default=False): cv.boolean,  # CRITICAL: Enable for SPF to prevent power reset
@@ -328,12 +334,6 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
     async def export_register_dump(call: ServiceCall) -> None:
         """Universal register scanner - scans all ranges and auto-detects model."""
-        connection_type = call.data.get("connection_type", "tcp")
-        host = call.data.get("host")
-        port = call.data.get("port", 502)
-        device = call.data.get("device")
-        baudrate = call.data.get("baudrate", 9600)
-        slave_id = call.data.get("slave_id", 1)
         send_notification = call.data.get("notify", True)
         offgrid_mode = call.data.get("offgrid_mode", False)
 
@@ -346,15 +346,47 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         if call.data.get("scan_vpp_control", True):  enabled_groups.add("vpp_control")
         if call.data.get("scan_vpp_data", True):     enabled_groups.add("vpp_data")
 
-        # Validate required parameters based on connection type
-        if connection_type == "tcp":
-            if not host:
-                _LOGGER.error("host parameter required for TCP connection")
+        # --- Resolve connection parameters ---
+        # If config_entry is provided, pull all connection details directly from the
+        # coordinator — no manual entry needed, profile/entity values always included.
+        pre_resolved_coordinator = None
+        config_entry_id = call.data.get("config_entry")
+
+        if config_entry_id:
+            coordinator = hass.data.get(DOMAIN, {}).get(config_entry_id)
+            if not coordinator or not hasattr(coordinator, 'entry'):
+                _LOGGER.error("config_entry '%s' not found in Growatt Modbus integration", config_entry_id)
                 return
-        elif connection_type == "serial":
-            if not device:
-                _LOGGER.error("device parameter required for serial connection")
-                return
+
+            entry_data = coordinator.entry.data
+            connection_type = entry_data.get("connection_type", "tcp")
+            host = entry_data.get("host")
+            port = entry_data.get("port", 502)
+            device = entry_data.get("device")
+            baudrate = entry_data.get("baudrate", 9600)
+            slave_id = entry_data.get("slave_id", 1)
+            pre_resolved_coordinator = coordinator
+            _LOGGER.info(
+                "Using config entry '%s' (%s) for register scan",
+                coordinator.entry.title, config_entry_id
+            )
+        else:
+            connection_type = call.data.get("connection_type", "tcp")
+            host = call.data.get("host")
+            port = call.data.get("port", 502)
+            device = call.data.get("device")
+            baudrate = call.data.get("baudrate", 9600)
+            slave_id = call.data.get("slave_id", 1)
+
+            # Validate required manual parameters
+            if connection_type == "tcp":
+                if not host:
+                    _LOGGER.error("host parameter required for TCP connection (or select a config_entry)")
+                    return
+            elif connection_type == "serial":
+                if not device:
+                    _LOGGER.error("device parameter required for serial connection (or select a config_entry)")
+                    return
 
         if offgrid_mode:
             _LOGGER.warning("⚠️ OffGrid mode ENABLED - skipping VPP registers to prevent power reset on SPF inverters")
@@ -365,9 +397,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         else:
             _LOGGER.info("Starting %s register scan on %s @ %d baud", "OffGrid" if offgrid_mode else "universal", device, baudrate)
 
-        # Run export in executor - coordinator will be auto-detected based on connection parameters
+        # Run export in executor — pass pre-resolved coordinator if available
         result = await hass.async_add_executor_job(
-            _export_registers_to_csv, hass, connection_type, host, port, device, baudrate, slave_id, offgrid_mode, enabled_groups
+            _export_registers_to_csv, hass, connection_type, host, port, device, baudrate, slave_id, offgrid_mode, enabled_groups, pre_resolved_coordinator
         )
         
         if result["success"]:
@@ -1601,7 +1633,7 @@ def _detect_inverter_model(register_data: Dict[int, Dict[str, Any]]) -> Dict[str
     return detection
 
 
-def _export_registers_to_csv(hass, connection_type: str, host: str, port: int, device: str, baudrate: int, slave_id: int, offgrid_mode: bool = False, enabled_groups: set = None) -> dict:
+def _export_registers_to_csv(hass, connection_type: str, host: str, port: int, device: str, baudrate: int, slave_id: int, offgrid_mode: bool = False, enabled_groups: set = None, coordinator=None) -> dict:
     """
     Export all registers to CSV file with auto-detection (blocking).
 
@@ -1613,8 +1645,9 @@ def _export_registers_to_csv(hass, connection_type: str, host: str, port: int, d
         baudrate: Serial baudrate for serial connection
         slave_id: Modbus slave ID
         offgrid_mode: If True, skip VPP registers (30000+, 31000+) to prevent SPF power resets
-
-    Note: Coordinator is auto-detected by matching connection parameters
+        coordinator: Pre-resolved coordinator (from config_entry selection). When provided,
+                     the auto-detection loop is skipped entirely — connection parameters and
+                     profile/entity values are sourced directly from this coordinator.
     """
     result = {
         "success": False,
@@ -1657,34 +1690,36 @@ def _export_registers_to_csv(hass, connection_type: str, host: str, port: int, d
         mode_str = "OffGrid scan (safe for SPF)" if offgrid_mode else "universal scan"
         _LOGGER.info(f"Connected, starting {mode_str}...")
 
-        # Auto-detect coordinator by matching connection parameters
-        coordinator = None
-        if hass.data.get(DOMAIN):
-            for entry_id, coord in hass.data[DOMAIN].items():
-                if not coord or not hasattr(coord, 'entry'):
-                    continue
+        # Resolve coordinator for profile/entity data.
+        # If pre-resolved via config_entry selection, use it directly.
+        # Otherwise fall back to matching by connection parameters.
+        if coordinator is not None:
+            _LOGGER.info("Using pre-resolved coordinator from config entry — entity values will be included")
+        else:
+            if hass.data.get(DOMAIN):
+                for entry_id, coord in hass.data[DOMAIN].items():
+                    if not coord or not hasattr(coord, 'entry'):
+                        continue
 
-                entry_data = coord.entry.data
+                    entry_data = coord.entry.data
 
-                # Match based on connection type
-                if connection_type == "tcp":
-                    # Match TCP connections by host and port
-                    if (entry_data.get("connection_type") == "tcp" and
-                        entry_data.get("host") == host and
-                        entry_data.get("port", 502) == port):
-                        coordinator = coord
-                        _LOGGER.info(f"Auto-detected coordinator for {host}:{port} - entity values will be included")
-                        break
-                else:  # serial
-                    # Match Serial connections by device path
-                    if (entry_data.get("connection_type") == "serial" and
-                        entry_data.get("device") == device):
-                        coordinator = coord
-                        _LOGGER.info(f"Auto-detected coordinator for {device} - entity values will be included")
-                        break
+                    # Match based on connection type
+                    if connection_type == "tcp":
+                        if (entry_data.get("connection_type") == "tcp" and
+                            entry_data.get("host") == host and
+                            entry_data.get("port", 502) == port):
+                            coordinator = coord
+                            _LOGGER.info(f"Auto-detected coordinator for {host}:{port} - entity values will be included")
+                            break
+                    else:  # serial
+                        if (entry_data.get("connection_type") == "serial" and
+                            entry_data.get("device") == device):
+                            coordinator = coord
+                            _LOGGER.info(f"Auto-detected coordinator for {device} - entity values will be included")
+                            break
 
-        if not coordinator:
-            _LOGGER.info("No matching coordinator found - entity values will not be included in CSV")
+            if not coordinator:
+                _LOGGER.info("No matching coordinator found - entity values will not be included in CSV")
 
         # Extract currently selected profile from coordinator (if available)
         selected_profile_key = None

--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -2004,14 +2004,19 @@ class GrowattModbus:
             seen_voltage_addrs: set = set()
             voltage_candidates: list = []
             for _vname in _VOLTAGE_LOOKUP_NAMES:
-                _a = (self._find_register_by_name_with_fallback(_vname) or
-                      self._find_register_by_name(_vname))
-                if _a and _a not in seen_voltage_addrs:
-                    seen_voltage_addrs.add(_a)
-                    _v = self._get_register_value(_a)
-                    if _v is not None and _VOLTAGE_MIN_V <= _v <= _VOLTAGE_MAX_V:
-                        voltage_candidates.append((_a, _v))
-                        logger.debug(f"Battery voltage candidate reg {_a} ({_vname}): {_v}V")
+                # Use _find_all_registers_by_name to get EVERY address for this name
+                # (including maps_to matches across all ranges). Previously only one
+                # address was returned (the preferred-range winner), so when the VPP range
+                # was preferred the native 8000-range register was never evaluated as a
+                # candidate — meaning the spurious VPP value was never compared against
+                # the correct native value. (Issue #247 root cause)
+                for _a in self._find_all_registers_by_name(_vname):
+                    if _a not in seen_voltage_addrs:
+                        seen_voltage_addrs.add(_a)
+                        _v = self._get_register_value(_a)
+                        if _v is not None and _VOLTAGE_MIN_V <= _v <= _VOLTAGE_MAX_V:
+                            voltage_candidates.append((_a, _v))
+                            logger.debug(f"Battery voltage candidate reg {_a} ({_vname}): {_v}V")
 
             if voltage_candidates:
                 _best_addr, _best_val = max(voltage_candidates, key=lambda c: c[1])
@@ -2038,14 +2043,15 @@ class GrowattModbus:
             seen_current_addrs: set = set()
             current_candidates: list = []
             for _cname in _CURRENT_LOOKUP_NAMES:
-                _a = (self._find_register_by_name_with_fallback(_cname) or
-                      self._find_register_by_name(_cname))
-                if _a and _a not in seen_current_addrs:
-                    seen_current_addrs.add(_a)
-                    _v = self._get_register_value(_a)
-                    if _v is not None and abs(_v) <= _CURRENT_MAX_A:
-                        current_candidates.append((_a, _v))
-                        logger.debug(f"Battery current candidate reg {_a} ({_cname}): {_v}A")
+                # Same fix as voltage: iterate ALL addresses per name so the native
+                # 8000-range register is always evaluated alongside the VPP register.
+                for _a in self._find_all_registers_by_name(_cname):
+                    if _a not in seen_current_addrs:
+                        seen_current_addrs.add(_a)
+                        _v = self._get_register_value(_a)
+                        if _v is not None and abs(_v) <= _CURRENT_MAX_A:
+                            current_candidates.append((_a, _v))
+                            logger.debug(f"Battery current candidate reg {_a} ({_cname}): {_v}A")
 
             if current_candidates:
                 _best_addr, _best_val = max(current_candidates, key=lambda c: abs(c[1]))

--- a/custom_components/growatt_modbus/manifest.json
+++ b/custom_components/growatt_modbus/manifest.json
@@ -12,5 +12,5 @@
     "pymodbus>=3.0.0",
     "pyserial>=3.4"
   ],
-  "version": "0.7.0"
+  "version": "0.7.1"
 }

--- a/custom_components/growatt_modbus/profiles/__init__.py
+++ b/custom_components/growatt_modbus/profiles/__init__.py
@@ -9,6 +9,8 @@ Profile Structure:
 - mod.py: MOD series (6-15kW three-phase hybrid)
 - tl_xh.py: TL-XH series (3-10kW hybrid)
 - sph.py: SPH series (storage/battery)
+- sph_tl3.py: SPH-TL3 series (three-phase hybrid with battery)
+- spa.py: SPA series (AC-coupled battery storage, no PV inputs)
 - spf.py: SPF series (off-grid with battery)
 - spe.py: SPE series (off-grid, larger capacity, SPF protocol)
 - wit.py: WIT series (4-15kW three-phase hybrid with advanced storage)
@@ -22,6 +24,7 @@ from .min import MIN_REGISTER_MAPS
 from .mid import MID_REGISTER_MAPS
 from .sph import SPH_REGISTER_MAPS
 from .sph_tl3 import SPH_TL3_REGISTER_MAPS
+from .spa import SPA_REGISTER_MAPS
 from .spf import SPF_REGISTER_MAPS
 from .spe import SPE_REGISTER_MAPS
 from .mod import MOD_REGISTER_MAPS
@@ -36,6 +39,7 @@ REGISTER_MAPS = {
     **MID_REGISTER_MAPS,
     **SPH_REGISTER_MAPS,
     **SPH_TL3_REGISTER_MAPS,
+    **SPA_REGISTER_MAPS,
     **SPF_REGISTER_MAPS,
     **SPE_REGISTER_MAPS,
     **MOD_REGISTER_MAPS,

--- a/custom_components/growatt_modbus/profiles/spa.py
+++ b/custom_components/growatt_modbus/profiles/spa.py
@@ -1,0 +1,98 @@
+# SPA Series - AC-Coupled Battery Storage (No PV MPPT Inputs)
+# Based on SPA 3000TL BL + Ark 2.5L-A1 register scans (issue #249)
+# Scan date: 2026-04 (day + night scans cross-verified)
+
+from .sph_tl3 import SPH_TL3_3000_10000
+
+SPA_3000_6000_TL_BL = {
+    'name': 'SPA (AC Storage) 3-6kW',
+    'description': 'AC-coupled battery storage inverter — no PV MPPT inputs (SPA 3000TL BL and similar)',
+    'notes': (
+        'Uses ONLY 1000-1124 register range. No solar DC inputs. '
+        'Base range (0-124) and 3000+ range respond with zeros — not exceptions. '
+        'Holding registers identical to SPH-TL3. '
+        'Load power is at reg 1037/1038 (SPH-TL3 reg 1021/1022 is zero on SPA).'
+    ),
+    'input_registers': {
+        # ============================================================================
+        # STORAGE RANGE 1000-1124 (the ONLY range with real data on SPA)
+        # ============================================================================
+
+        # System Work Mode
+        1000: {'name': 'system_work_mode', 'scale': 1, 'unit': '', 'desc': 'Work mode'},
+
+        # Battery Discharge/Charge Power
+        1009: {'name': 'discharge_power_high', 'scale': 1, 'unit': '', 'pair': 1010},
+        1010: {'name': 'discharge_power_low', 'scale': 1, 'unit': '', 'pair': 1009,
+               'combined_scale': 0.1, 'combined_unit': 'W'},
+        1011: {'name': 'charge_power_high', 'scale': 1, 'unit': '', 'pair': 1012},
+        1012: {'name': 'charge_power_low', 'scale': 1, 'unit': '', 'pair': 1011,
+               'combined_scale': 0.1, 'combined_unit': 'W'},
+
+        # Battery State
+        1013: {'name': 'battery_voltage', 'scale': 0.1, 'unit': 'V'},
+        1014: {'name': 'battery_soc', 'scale': 1, 'unit': '%'},
+        1040: {'name': 'battery_temp', 'scale': 0.1, 'unit': '°C', 'signed': True},
+        1041: {'name': 'battery_type', 'scale': 1, 'unit': ''},
+
+        # Power Flow
+        # NOTE: SPH-TL3 maps power_to_load at 1021/1022 — those registers are zero on SPA.
+        #       Load power on SPA is at 1037/1038 (mapped here as power_to_load).
+        1029: {'name': 'power_to_grid_high', 'scale': 1, 'unit': '', 'pair': 1030},
+        1030: {'name': 'power_to_grid_low', 'scale': 1, 'unit': '', 'pair': 1029,
+               'combined_scale': 0.1, 'combined_unit': 'W', 'signed': True},
+        1037: {'name': 'power_to_load_high', 'scale': 1, 'unit': '', 'pair': 1038},
+        1038: {'name': 'power_to_load_low', 'scale': 1, 'unit': '', 'pair': 1037,
+               'combined_scale': 0.1, 'combined_unit': 'W'},
+
+        # AC Grid Voltage
+        # Reg 1105 (input FC04) = ~21575 raw → ×0.01 = 215.75V on UK 230V grid.
+        # Constant between day/night scans — consistent with mains voltage.
+        # NOTE: Tentative — user confirmation pending. Not to be confused with
+        #       holding reg 1105 (FC03) = time_period_2_enable, a separate register space.
+        1105: {'name': 'ac_voltage', 'scale': 0.01, 'unit': 'V',
+               'desc': 'Grid/AC voltage (SPA input reg 1105, scale ×0.01; confirmed ~216V on 230V grid)'},
+
+        # Energy Breakdown (all registers confirmed from day + night cross-scan analysis)
+        1044: {'name': 'energy_to_user_today_high', 'scale': 1, 'unit': '', 'pair': 1045},
+        1045: {'name': 'energy_to_user_today_low', 'scale': 1, 'unit': '', 'pair': 1044,
+               'combined_scale': 0.1, 'combined_unit': 'kWh'},
+        1046: {'name': 'energy_to_user_total_high', 'scale': 1, 'unit': '', 'pair': 1047},
+        1047: {'name': 'energy_to_user_total_low', 'scale': 1, 'unit': '', 'pair': 1046,
+               'combined_scale': 0.1, 'combined_unit': 'kWh'},
+        1048: {'name': 'energy_to_grid_today_high', 'scale': 1, 'unit': '', 'pair': 1049},
+        1049: {'name': 'energy_to_grid_today_low', 'scale': 1, 'unit': '', 'pair': 1048,
+               'combined_scale': 0.1, 'combined_unit': 'kWh'},
+        1050: {'name': 'energy_to_grid_total_high', 'scale': 1, 'unit': '', 'pair': 1051},
+        1051: {'name': 'energy_to_grid_total_low', 'scale': 1, 'unit': '', 'pair': 1050,
+               'combined_scale': 0.1, 'combined_unit': 'kWh'},
+        1052: {'name': 'discharge_energy_today_high', 'scale': 1, 'unit': '', 'pair': 1053},
+        1053: {'name': 'discharge_energy_today_low', 'scale': 1, 'unit': '', 'pair': 1052,
+               'combined_scale': 0.1, 'combined_unit': 'kWh'},
+        1054: {'name': 'discharge_energy_total_high', 'scale': 1, 'unit': '', 'pair': 1055},
+        1055: {'name': 'discharge_energy_total_low', 'scale': 1, 'unit': '', 'pair': 1054,
+               'combined_scale': 0.1, 'combined_unit': 'kWh'},
+        1056: {'name': 'charge_energy_today_high', 'scale': 1, 'unit': '', 'pair': 1057},
+        1057: {'name': 'charge_energy_today_low', 'scale': 1, 'unit': '', 'pair': 1056,
+               'combined_scale': 0.1, 'combined_unit': 'kWh'},
+        1058: {'name': 'charge_energy_total_high', 'scale': 1, 'unit': '', 'pair': 1059},
+        1059: {'name': 'charge_energy_total_low', 'scale': 1, 'unit': '', 'pair': 1058,
+               'combined_scale': 0.1, 'combined_unit': 'kWh'},
+        1060: {'name': 'load_energy_today_high', 'scale': 1, 'unit': '', 'pair': 1061},
+        1061: {'name': 'load_energy_today_low', 'scale': 1, 'unit': '', 'pair': 1060,
+               'combined_scale': 0.1, 'combined_unit': 'kWh'},
+        1062: {'name': 'load_energy_total_high', 'scale': 1, 'unit': '', 'pair': 1063},
+        1063: {'name': 'load_energy_total_low', 'scale': 1, 'unit': '', 'pair': 1062,
+               'combined_scale': 0.1, 'combined_unit': 'kWh'},
+    },
+    'holding_registers': {
+        # Confirmed identical to SPH-TL3 from entity values in scan:
+        # priority_mode, discharge_stopped_soc, charge_power_rate, time_period_1/2/3
+        **SPH_TL3_3000_10000['holding_registers'],
+    },
+}
+
+# Export all SPA profiles
+SPA_REGISTER_MAPS = {
+    'SPA_3000_6000_TL_BL': SPA_3000_6000_TL_BL,
+}

--- a/custom_components/growatt_modbus/profiles/spe.py
+++ b/custom_components/growatt_modbus/profiles/spe.py
@@ -5,12 +5,6 @@ The SPE 8000-12000 ES is a single-phase hybrid inverter with battery storage,
 dual MPPT trackers, and grid-tied peak shaving capability. It supports parallel
 operation for capacity expansion up to 108kW.
 
-Uses the same off-grid protocol as SPF (registers 0-97) for sensor data.
-Identified via Issue #212 register scan analysis — nighttime data perfectly
-matches SPF register layout across 15+ registers including battery voltage
-(53.67V at ×0.01), SOC (97%), AC voltages (230.8V, 231.0V), frequencies
-(49.99Hz, 50.02Hz), temperatures, and a fully consistent power balance.
-
 Key characteristics:
 - 8-12kW capacity, single-phase hybrid
 - Dual MPPT trackers (PV1 + PV2), max PV input 550VDC
@@ -19,32 +13,133 @@ Key characteristics:
 - Parallel operation support (up to 108kW)
 - Dual outputs for smart load management
 
+Register Layout Notes (from Issue #212 register scan analysis):
+- Uses the same 0-97 base register range as SPF
+- Register layout shares many SPF-compatible addresses but has key differences:
+  * Regs 36/37: SPF uses these for ac_input_power; SPE produces garbage (429GW overflow)
+    → These registers are excluded from this profile until the correct mapping is confirmed
+  * Regs 64/65: SPF = AC discharge energy today; SPE = grid import energy today (confirmed 20.0 kWh)
+  * Regs 66/67: SPF = AC discharge energy total; SPE = grid import energy total (confirmed 855.2 kWh)
+  * Regs 85/86: SPF = op discharge energy today; SPE = load energy today (confirmed 21.3 kWh)
+  * Regs 87/88: SPF = op discharge energy total; SPE = load energy total (confirmed 1028.3 kWh)
+  * Regs 92-97: Generator registers — SPE has no generator input, all zero
+- offgrid_protocol flag prevents reading VPP registers (30000+) which return garbage on this firmware
+
+DTC Identification:
+- This device returned DTC 64541 (unknown, not in standard mapping) in the Issue #212 scan
+- Auto-detection falls back to legacy range analysis for this device
+- See auto_detection.py for manual profile override instructions
+
 Battery Power Sign Convention:
-Same as SPF — uses INVERTED sign convention (positive=discharge, negative=charge).
-Negative scale (-0.1) on registers 77-78 converts to standard convention.
+Same as SPF — hardware reports inverted convention (positive=discharge, negative=charge).
+Negative scale (-0.1) on registers 77/78 converts to standard HA convention.
 """
 
 from .spf import SPF_3000_6000_ES_PLUS
 
+# Build SPE input registers by modifying the SPF base
+# All confirmed register mappings are validated against Issue #212 daytime scan
+# cross-referenced with actual entity values from the XLSX file
+_spe_input_regs = dict(SPF_3000_6000_ES_PLUS['input_registers'])
+
+# ── Remove registers that are wrong or absent on SPE ──────────────────────────
+
+# Regs 36/37: SPF maps these as ac_input_power_high/low but SPE produces 429GW overflow.
+# The 32-bit value appears to be a signed grid power register that the coordinator
+# interprets as unsigned, yielding 0xFFFFFFE4 → 4,294,966,436 × 0.1 = 429,496,643.6W.
+# Excluded until the correct signed semantics are confirmed from a cleaner scan.
+for _addr in (36, 37):
+    _spe_input_regs.pop(_addr, None)
+
+# Regs 92-97: Generator discharge energy, generator power, generator voltage.
+# SPE has no generator input port — these registers are all zero and inapplicable.
+for _addr in (92, 93, 94, 95, 96, 97):
+    _spe_input_regs.pop(_addr, None)
+
+# ── Remap energy registers: SPF names are semantically wrong for SPE ──────────
+
+# Regs 64/65: SPF labels these "AC discharge energy today" (battery-to-load via inverter).
+# On SPE these registers track GRID IMPORT energy today.
+# Confirmed: scan raw 200 × 0.1 = 20.0 kWh, actual grid import = 19.8 kWh ✓
+_spe_input_regs.update({
+    64: {
+        'name': 'ac_discharge_energy_today_high', 'scale': 1, 'unit': '', 'pair': 65,
+        'desc': 'Grid import energy today (HIGH word) [SPE: different semantics from SPF at same address]',
+    },
+    65: {
+        'name': 'ac_discharge_energy_today_low', 'scale': 1, 'unit': '', 'pair': 64,
+        'combined_scale': 0.1, 'combined_unit': 'kWh',
+        'desc': 'Grid import energy today (LOW word). Confirmed ≈ 20.0 kWh (#212)',
+    },
+})
+
+# Regs 66/67: SPF labels these "AC discharge energy total".
+# On SPE these registers track GRID IMPORT energy total (lifetime).
+# Confirmed: scan raw 8552 × 0.1 = 855.2 kWh, actual = 855.2 kWh ✓
+_spe_input_regs.update({
+    66: {
+        'name': 'ac_discharge_energy_total_high', 'scale': 1, 'unit': '', 'pair': 67,
+        'desc': 'Grid import energy total (HIGH word)',
+    },
+    67: {
+        'name': 'ac_discharge_energy_total_low', 'scale': 1, 'unit': '', 'pair': 66,
+        'combined_scale': 0.1, 'combined_unit': 'kWh',
+        'desc': 'Grid import energy total (LOW word). Confirmed 855.2 kWh (#212)',
+    },
+})
+
+# Regs 85/86: SPF labels these "operational discharge energy today".
+# On SPE these registers track LOAD ENERGY consumed today (all sources: PV + grid + battery).
+# Confirmed: scan raw 213 × 0.1 = 21.3 kWh, actual load today = 20.9 kWh ✓
+_spe_input_regs.update({
+    85: {
+        'name': 'load_energy_today_high', 'scale': 1, 'unit': '', 'pair': 86,
+        'desc': 'Load energy today (HIGH word)',
+    },
+    86: {
+        'name': 'load_energy_today_low', 'scale': 1, 'unit': '', 'pair': 85,
+        'combined_scale': 0.1, 'combined_unit': 'kWh',
+        'desc': 'Load energy today (LOW word). Confirmed 21.3 kWh actual 20.9 kWh (#212)',
+    },
+})
+
+# Regs 87/88: SPF labels these "operational discharge energy total".
+# On SPE these registers track LOAD ENERGY consumed total (lifetime).
+# Confirmed: scan raw 10283 × 0.1 = 1028.3 kWh, actual load total = 1027.9 kWh ✓
+_spe_input_regs.update({
+    87: {
+        'name': 'load_energy_total_high', 'scale': 1, 'unit': '', 'pair': 88,
+        'desc': 'Load energy total (HIGH word)',
+    },
+    88: {
+        'name': 'load_energy_total_low', 'scale': 1, 'unit': '', 'pair': 87,
+        'combined_scale': 0.1, 'combined_unit': 'kWh',
+        'desc': 'Load energy total (LOW word). Confirmed 1028.3 kWh actual 1027.9 kWh (#212)',
+    },
+})
+
 SPE_8000_12000_ES = {
     'name': 'SPE 8000-12000 ES',
     'description': 'Single-phase hybrid inverter with battery storage (8-12kW)',
-    'notes': 'Uses SPF off-grid protocol (0-97 range). Identified from Issue #212 scan. Needs daytime validation.',
+    'notes': (
+        'Uses SPF-compatible 0-97 register range with key remapping. '
+        'Regs 64/65 = grid import energy (not AC discharge), '
+        'Regs 85-88 = load energy today/total (not operational discharge). '
+        'Regs 36/37 (ac_input_power) excluded — produces 429GW overflow. '
+        'No generator input. PV register validation pending daytime scan.'
+    ),
     # NOTE: offgrid_protocol refers to the REGISTER LAYOUT (SPF-style 0-97),
     # not the inverter's grid capability. The SPE supports grid-tied operation
     # with peak shaving. This flag prevents reading VPP registers (30000+)
-    # which return garbage data on this device.
+    # which return garbage data on this device firmware.
     'offgrid_protocol': True,
-    'input_registers': {
-        **SPF_3000_6000_ES_PLUS['input_registers'],
-        # SPE-specific overrides or additions can go here
-        # once daytime scan confirms additional registers
-    },
+    'input_registers': _spe_input_regs,
     'holding_registers': {
+        # Holding registers inherited from SPF — confirmed consistent with
+        # entity values seen in Issue #212 scan (charge_current, battery_type,
+        # ac_input_mode, output_config, charge_config all reading correctly).
         **SPF_3000_6000_ES_PLUS['holding_registers'],
-        # SPE may have different control register layout
-        # Holding registers need validation with user
-    }
+    },
 }
 
 # Export register maps for import by __init__.py

--- a/custom_components/growatt_modbus/profiles/wit.py
+++ b/custom_components/growatt_modbus/profiles/wit.py
@@ -425,6 +425,19 @@ WIT_4000_15000TL3 = {
                 }},
 
         # VPP Export Limitation Control
+        # NOTE: Register 30208 (Export Limitation Protection Mode) is NOT used by:
+        #   SPA 4000-10000TL3 BH-UP (DTC 3725), SPH 4000-10000TL3 BH-UP (DTC 3601),
+        #   WIT 100KTL3-H (DTC 5601), WIS 215KTL3 (DTC 5800)
+        # Mode descriptions for reference (VPP 2.01/2.03 documentation):
+        #   0: Default mode — meter disconnect limits output to Export Limitation Failure Power;
+        #      output > Export Limitation Power → inverter reports error and goes off-grid
+        #   1: Combine control mode — meter disconnect → error + off-grid within 5s;
+        #      anti-backflow failure → off-grid after 15s
+        #   2: Software control mode — meter disconnect reduces output to Failure Power in 15s;
+        #      output > Export Limit → reduces to Failure Power in 15s
+        #   3: Hardware control mode — meter disconnect → error + off-grid within 5s;
+        #      output > Export Limit → off-grid within 5s
+        # Register 30208 is not implemented here for WIT; if needed add to applicable DTC profiles only.
         30200: {'name': 'vpp_export_limit_enable', 'scale': 1, 'unit': '', 'access': 'RW',
                 'desc': 'Export limitation master switch',
                 'valid_range': (0, 1),
@@ -467,6 +480,12 @@ WIT_4000_15000TL3 = {
                 'valid_range': (10, 100), 'desc': 'Stop charging when SOC reaches this %'},
         30405: {'name': 'vpp_discharge_cutoff_soc', 'scale': 1, 'unit': '%', 'access': 'RW',
                 'valid_range': (10, 100), 'desc': 'Stop on-grid discharge when SOC drops to this %'},
+        # NOTE: Register 30406 (Load Priority Discharge Cutoff SOC) is device-type specific.
+        # Only applicable to Load-first mode (priority_mode=0) on:
+        #   SPH 3000-6000TL BL (DTC 3502), SPA 3000-6000TL BL (DTC 3735),
+        #   SPH (DTC 3750 variants), SPH 4000-10000TL3 BH-UP (DTC 3601)
+        # This register is NOT applicable to WIT (DTC 5603) and is therefore
+        # not implemented here. Add to sph/spa profiles if load-priority SOC cutoff control is needed.
 
         # AC Charging Enable (NOTE: May return "Illegal function" on some WIT firmware)
         30410: {'name': 'vpp_ac_charge_enable', 'scale': 1, 'unit': '', 'access': 'RW',

--- a/custom_components/growatt_modbus/services.yaml
+++ b/custom_components/growatt_modbus/services.yaml
@@ -90,11 +90,26 @@ update_register_map:
 
 export_register_dump:
   name: Universal Register Scanner
-  description: Scan ALL register ranges, auto-detect your inverter model, and export complete register dump to CSV. Supports both TCP and USB/Serial connections. Entity values are automatically included if you have a configured device with matching connection parameters. File saved to /config/growatt_register_scan_[timestamp].csv
+  description: >
+    Scan ALL register ranges, auto-detect your inverter model, and export a complete register dump
+    to CSV. Select a configured device below to automatically use its connection settings and include
+    current entity values in the scan. Alternatively leave the device blank and enter connection
+    parameters manually (useful for scanning a new inverter before adding it to the integration).
+    File saved to /config/growatt_register_scan_[timestamp].csv
   fields:
+    config_entry:
+      name: Device (recommended)
+      description: >
+        Select your Growatt inverter from the list. Connection details and current entity values
+        are pulled directly from the integration — no manual IP/serial entry needed.
+        Leave blank to enter connection parameters manually.
+      required: false
+      selector:
+        config_entry:
+          integration: growatt_modbus
     connection_type:
-      name: Connection Type
-      description: Select TCP (RS485-to-Ethernet adapter) or Serial (RS485-to-USB adapter)
+      name: Connection Type (manual only)
+      description: Select TCP or Serial. Ignored when a device is selected above.
       required: false
       default: "tcp"
       selector:
@@ -105,15 +120,15 @@ export_register_dump:
             - label: "Serial (USB)"
               value: "serial"
     host:
-      name: IP Address (TCP only)
-      description: IP address of your RS485-TCP adapter (required for TCP connection)
+      name: IP Address (manual TCP only)
+      description: IP address of your RS485-TCP adapter. Ignored when a device is selected above.
       required: false
       example: "192.168.1.60"
       selector:
         text:
     port:
-      name: Port (TCP only)
-      description: Modbus TCP port (usually 502, required for TCP connection)
+      name: Port (manual TCP only)
+      description: Modbus TCP port (usually 502). Ignored when a device is selected above.
       required: false
       default: 502
       selector:
@@ -122,15 +137,15 @@ export_register_dump:
           max: 65535
           mode: box
     device:
-      name: Serial Device (Serial only)
-      description: Serial port path for USB adapter (required for Serial connection)
+      name: Serial Device (manual Serial only)
+      description: Serial port path for USB adapter (e.g. /dev/ttyUSB0 or COM3). Ignored when a device is selected above.
       required: false
       example: "/dev/ttyUSB0 or COM3"
       selector:
         text:
     baudrate:
-      name: Baudrate (Serial only)
-      description: Serial communication speed (usually 9600 for Growatt)
+      name: Baudrate (manual Serial only)
+      description: Serial communication speed (usually 9600 for Growatt). Ignored when a device is selected above.
       required: false
       default: "9600"
       selector:
@@ -143,8 +158,8 @@ export_register_dump:
             - "57600"
             - "115200"
     slave_id:
-      name: Slave ID
-      description: Modbus slave/unit ID (usually 1)
+      name: Slave ID (manual only)
+      description: Modbus slave/unit ID (usually 1). Ignored when a device is selected above.
       required: false
       default: 1
       selector:

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -32,6 +32,7 @@ When you add the integration, it attempts to identify your inverter automaticall
 | Model | Range | PV Strings | VPP Support | Auto-detect | Tested | Notes |
 |-------|-------|-----------|-------------|-------------|--------|-------|
 | **MIN TL-XH 3000-10000** | 3–10 kW | 2–3 | VPP | DTC 5100 | ✅ | 3–6kW: 2 strings; 7–10kW: 3 strings |
+| **SPA 3000-6000TL BL** | 3–6 kW | None | Legacy only | Auto | ✅ | AC-coupled storage only — no PV DC inputs |
 | **SPE 8000-12000 ES** | 8–12 kW | 2 | VPP-like | Model name | ✅ | Peak shaving, parallel operation |
 | **SPH 3000-6000** | 3–6 kW | 2 | VPP + Legacy | Model name | ✅ | |
 | **SPH 7000-10000** | 7–10 kW | 2 | VPP + Legacy | Model name | ✅ | |
@@ -64,42 +65,43 @@ When you add the integration, it attempts to identify your inverter automaticall
 
 ## Sensor Availability by Model
 
-| Sensor | MIC | MIN 3-6k | MIN 7-10k | MIN TL-XH | SPH 3-6k | SPH 7-10k | SPF | SPH-TL3 | MID | MOD | WIT |
-|--------|:---:|:--------:|:---------:|:---------:|:--------:|:---------:|:---:|:-------:|:---:|:---:|:---:|
-| **Solar Input** | | | | | | | | | | | |
-| PV1 Voltage/Current/Power | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| PV2 Voltage/Current/Power | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| PV3 Voltage/Current/Power | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Solar Total Power | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **AC Output (Single-Phase)** | | | | | | | | | | | |
-| AC Voltage / Current / Power | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| AC Apparent Power | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| AC Frequency | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **AC Output (Three-Phase)** | | | | | | | | | | | |
-| Phase R/S/T Voltage / Current / Power | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
-| AC Total Power | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
-| **Power Flow** | | | | | | | | | | | |
-| Grid Export / Import Power | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| House Consumption (calculated) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Self Consumption | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Power to Grid / Load / User (registers) | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| **Battery (Hybrid/Off-Grid)** | | | | | | | | | | | |
-| Battery Voltage / Current / Power | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| Battery SOC | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| Battery Temperature | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| BMS SOH / Cell Voltages | ❌ | ❌ | ❌ | ❌ | ❌ | ✅* | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **Energy Totals** | | | | | | | | | | | |
-| Energy Today / Total (PV) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Energy to Grid Today / Total | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Load Energy Today / Total | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Charge / Discharge Energy Today / Total | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| AC Charge Energy Today / Total | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| **System & Diagnostics** | | | | | | | | | | | |
-| Inverter / IPM Temperature | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Boost Temperature | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Status / Derating / Fault Codes | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Sensor | MIC | MIN 3-6k | MIN 7-10k | MIN TL-XH | SPA | SPH 3-6k | SPH 7-10k | SPF | SPH-TL3 | MID | MOD | WIT |
+| -------- | :---: | :--------: | :---------: | :---------: | :---: | :--------: | :---------: | :---: | :-------: | :---: | :---: | :---: |
+| **Solar Input** | | | | | | | | | | | | |
+| PV1 Voltage/Current/Power | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| PV2 Voltage/Current/Power | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| PV3 Voltage/Current/Power | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Solar Total Power | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **AC Output (Single-Phase)** | | | | | | | | | | | | |
+| AC Voltage / Current / Power | ✅ | ✅ | ✅ | ✅ | ⚠️† | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| AC Apparent Power | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| AC Frequency | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **AC Output (Three-Phase)** | | | | | | | | | | | | |
+| Phase R/S/T Voltage / Current / Power | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
+| AC Total Power | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
+| **Power Flow** | | | | | | | | | | | | |
+| Grid Export / Import Power | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| House Consumption (calculated) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Self Consumption | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Power to Grid / Load / User (registers) | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| **Battery (Hybrid/Off-Grid)** | | | | | | | | | | | | |
+| Battery Voltage / Current / Power | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Battery SOC | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Battery Temperature | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| BMS SOH / Cell Voltages | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅* | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Energy Totals** | | | | | | | | | | | | |
+| Energy Today / Total (PV) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Energy to Grid Today / Total | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Load Energy Today / Total | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Charge / Discharge Energy Today / Total | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| AC Charge Energy Today / Total | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| **System & Diagnostics** | | | | | | | | | | | | |
+| Inverter / IPM Temperature | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Boost Temperature | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Status / Derating / Fault Codes | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 *HU variants only (SPH/SPM 8000-10000TL3-BH-HU)
+†AC voltage only (reg 1105, scale ×0.01); AC current/power and frequency not confirmed for SPA
 
 ---
 
@@ -161,6 +163,7 @@ If auto-detection fails (or you want to override), choose based on:
 | Select this | PV Strings | Power | When |
 |-------------|-----------|-------|------|
 | MIN TL-XH 3000-10000 | 2–3 | 3–10 kW | Battery hybrid (3–6kW: 2 strings, 7–10kW: 3 strings) |
+| SPA 3000-6000TL BL | None | 3–6 kW | AC-coupled battery storage only (no PV inputs) |
 | SPE 8000-12000 ES | 2 | 8–12 kW | Battery hybrid, peak shaving |
 | SPF 3000-6000 ES PLUS | 2 | 3–6 kW | Off-grid with battery |
 | SPH 3000-6000 | 2 | 3–6 kW | Battery hybrid |


### PR DESCRIPTION
Release Notes

<a href="https://www.buymeacoffee.com/0xAHA" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>

---

## v0.7.1

Issues: #249 · #242 · #212

---

### New Profiles

- **SPA series — new profile (#249):** The SPA 3000–6000TL BL (AC-coupled battery storage,
  no PV MPPT inputs) now has a dedicated profile. Previously it auto-detected as
  MIN 7000-10000TL-X and all sensors read zero; with SPH-TL3 manually selected, AC voltage,
  frequency, and load power also read zero because the SPA never populates the 0-124
  register range. The new `spa_3000_6000_tl_bl` profile reads exclusively from the
  1000-1124 range where the SPA keeps all its data. Load power is correctly sourced from
  registers 1037/1038 (SPH-TL3 uses 1021/1022 for this, which are zero on the SPA).
  Confirmed sensors: battery voltage/SOC/temp/type, charge/discharge power, power to grid,
  load power, AC voltage (~216V at reg 1105), and the full energy breakdown set
  (energy to user/grid today/total, battery charge/discharge today/total, load energy
  today/total). Holding register layout (battery management, TOU time periods) is identical
  to SPH-TL3.

### Universal Register Scanner — Device Selector

The Universal Register Scanner service now has a **Device** dropdown at the top of the service
form. Selecting your configured inverter pre-fills all connection details (IP, port, serial path,
baudrate, slave ID) and guarantees that the "CURRENTLY CONFIGURED PROFILE" and "CURRENT ENTITY
VALUES" sections appear in the CSV output. Previously, entity values were only included when the
scanner could match the connection parameters you typed against a running integration entry, which
silently failed for serial connections if the device path differed even slightly. Manual IP/serial
entry fields are still available for scanning a new inverter before it has been added to the
integration.

### Bug Fixes

- **WIT 8K-HU — Battery voltage/current fix (take 2) (#247):** The v0.7.0 multi-candidate
  selection was not actually comparing the VPP register (31214, spurious 5.2V) against the
  native register (8034, correct 53.7V). The candidate loop used
  `_find_register_by_name_with_fallback()` which filters down to a single address based on
  the detected preferred range — so when the VPP range scored non-zero (because 31214 returns
  a wrong-but-non-zero value), only reg 31214 was ever evaluated as a candidate and reg 8034
  was never read. Fixed by replacing the single-address lookup with
  `_find_all_registers_by_name()` so every matching address across all ranges is evaluated.
  The 5.2V value at reg 31214 is then correctly discarded by the 10V plausibility floor and
  the 53.7V from reg 8034 is selected. The same fix is applied to battery current.

### Profile Fixes

- **SPE 8000-12000 ES — register map corrected (#212):** The SPE profile previously inherited
  the SPF register map wholesale. Cross-analysis of the Issue #212 daytime scan against actual
  entity values (from the accompanying XLSX file) revealed several incorrect mappings:
  - Registers 36/37 (`ac_input_power`) produce a 429 GW overflow on SPE — the value is a
    signed 32-bit grid power register that the coordinator interprets as unsigned. These
    registers have been removed from the profile until correct signed semantics are confirmed.
  - Registers 64/65 (SPF: "AC discharge energy today") are **grid import energy today** on SPE.
    Confirmed: 20.0 kWh scan value vs 19.8 kWh actual ✓
  - Registers 66/67 (SPF: "AC discharge energy total") are **grid import energy total** on SPE.
    Confirmed: 855.2 kWh ✓
  - Registers 85/86 (SPF: "operational discharge energy today") are **load energy today** on SPE.
    Confirmed: 21.3 kWh vs 20.9 kWh actual ✓
  - Registers 87/88 (SPF: "operational discharge energy total") are **load energy total** on SPE.
    Confirmed: 1028.3 kWh vs 1027.9 kWh actual ✓
  - Registers 92–97 (generator discharge/power/voltage) removed — SPE has no generator input.
    All confirmed registers (battery voltage 50.12 V, grid voltage 235.8 V, PV1/PV2 voltage/power,
    temperatures, fan speeds, charge/discharge energy totals) remain correctly inherited from SPF.

### Auto-Detection Fixes

- **SPA auto-detection (#249):** SPA responds to all register ranges with zeros rather than
  exceptions, causing it to fall through into the MIN detection branch. Detection now checks
  register 1013 (battery voltage, always ~530 raw = 53 V on SPA) combined with register 38
  (AC voltage in base range, always 0 on SPA). This check runs before the MIN series check.
  SPH-TL3 is not affected — it always has register 38 > 0 (grid voltage present even at
  night). SPH 3-6kW is not affected — its battery voltage is at register 13, not 1013.
- **MIC misclassification of legacy string inverters fixed (#242):** Inverters using the
  legacy 0-124 register range but lacking the 3000+ range were incorrectly detected as MIC
  micro inverters if their PV voltage happened to be non-zero at register 3. MIC micro
  inverters operate at low panel voltages (< 80 V raw). The detection now checks: if reg 3
  raw > 800 (> 80 V) and the 3000+ range is absent, the device is a legacy string inverter,
  not a MIC. It falls back to `min_7000_10000_tl_x` as the closest approximation and logs a
  warning. A dedicated legacy profile for this firmware class (DM1.0, ~11 kW, 3 strings,
  0-124 range only) is planned pending further scan data and model confirmation.