### PR TITLE
v0.7.4 — fix sensors missing after offline cold-start (Issue #262)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Growatt Modbus Integration for Home Assistant ☀️
 
 ![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange.svg)
-![Version](https://img.shields.io/badge/Version-0.7.3-blue.svg)
+![Version](https://img.shields.io/badge/Version-0.7.4-blue.svg)
 [![GitHub Issues](https://img.shields.io/github/issues/0xAHA/Growatt_ModbusTCP.svg)](https://github.com/0xAHA/Growatt_ModbusTCP/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/0xAHA/Growatt_ModbusTCP.svg?style=social)](https://github.com/0xAHA/Growatt_ModbusTCP)
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,34 @@
 
 ---
 
+## v0.7.4
+
+Issues: #262
+
+---
+
+- **Fix: Sensors missing after HA restart with inverter offline (#262):** When Home Assistant
+  restarts while the inverter is unreachable (e.g. overnight), the v0.7.3 fix for issue #255
+  correctly loads the integration with an empty placeholder rather than failing. However, sensor
+  entities whose creation is gated on runtime-detected hardware attributes — including
+  **State of Health** (`battery_soh`), **BMS State of Health** (`bms_soh`), **VPP export
+  limit** and **VPP control authority** controls, and a number of other optional sensors — were
+  evaluated against the empty placeholder at setup time, saw no data, and were permanently
+  skipped for that HA session.
+
+  The fix: when the inverter responds for the first time after such a cold-start, the integration
+  schedules a config entry reload. The reload fires on the next event loop tick (after the current
+  poll completes), re-runs all platform setup with real live data, and correctly registers every
+  sensor and control entity. The reload happens **at most once per HA session** and only when the
+  inverter was genuinely offline at startup.
+
+  **Affected entities (examples):** `battery_soh`, `bms_soh`, `battery_voltage_bms`,
+  `vpp_export_limit_enable`, `control_authority`, and any other sensor whose presence depends on
+  a register that only responds on certain hardware variants (generator sensors, extra buck
+  temperature sensors, WIT parallel-inverter sensors, etc.).
+
+---
+
 ## v0.7.3
 
 Issues: #249 · #253 · #254 · #255 · #256 · #257 · #225 · #259

--- a/custom_components/growatt_modbus/coordinator.py
+++ b/custom_components/growatt_modbus/coordinator.py
@@ -147,6 +147,12 @@ class GrowattModbusCoordinator(DataUpdateCoordinator[GrowattData]):
         # Used to distinguish a cold-start recovery (preserve storage-loaded daily retention)
         # from a normal overnight recovery (clear retention to trigger stale-value debounce).
         self._ever_had_real_data = False
+        # True if at least one poll failed before the first successful read.
+        # Used to trigger a config entry reload when the inverter first responds after a
+        # cold-start with the inverter offline, so that sensors whose entity creation is
+        # gated on runtime-detected data attributes (e.g. battery_soh, VPP controls) are
+        # correctly registered now that real data is available. (Issue #262)
+        self._startup_had_offline_poll = False
 
         # Adaptive polling for offline inverters
         self._consecutive_failures = 0
@@ -555,6 +561,7 @@ class GrowattModbusCoordinator(DataUpdateCoordinator[GrowattData]):
                     )
                     from .growatt_modbus import GrowattData
                     self.data = GrowattData()
+                    self._startup_had_offline_poll = True
 
                 _LOGGER.debug("Inverter offline - applying smart offline behavior")
 
@@ -624,6 +631,21 @@ class GrowattModbusCoordinator(DataUpdateCoordinator[GrowattData]):
                         "Cold-start recovery — preserving storage-loaded daily retention (%d values)",
                         len(self._retained_daily_totals)
                     )
+
+                    # If HA started while the inverter was offline, sensor entities whose creation
+                    # is gated on runtime-detected attributes (e.g. battery_soh, VPP controls) were
+                    # skipped during setup because the placeholder GrowattData() had no real data.
+                    # Now that the inverter has responded, reload the config entry so all platforms
+                    # re-run their setup with live data and create the missing entities. (Issue #262)
+                    if self._startup_had_offline_poll:
+                        self._startup_had_offline_poll = False
+                        _LOGGER.info(
+                            "Inverter responded after offline cold-start — scheduling config entry "
+                            "reload so all sensor entities are correctly registered (Issue #262)"
+                        )
+                        self.hass.async_create_task(
+                            self.hass.config_entries.async_reload(self.entry.entry_id)
+                        )
 
                 self._ever_had_real_data = True
 
@@ -714,6 +736,7 @@ class GrowattModbusCoordinator(DataUpdateCoordinator[GrowattData]):
                 "Sensors will be unavailable until the inverter responds."
             )
             self.data = GrowattData()
+            self._startup_had_offline_poll = True
             return self.data
 
     def _fetch_data(self) -> GrowattData | None:

--- a/custom_components/growatt_modbus/manifest.json
+++ b/custom_components/growatt_modbus/manifest.json
@@ -12,5 +12,5 @@
     "pymodbus>=3.0.0",
     "pyserial>=3.4"
   ],
-  "version": "0.7.3"
+  "version": "0.7.4"
 }


### PR DESCRIPTION
When HA restarted while the inverter was offline, the v0.7.3 placeholder
GrowattData() caused all condition-gated sensor entities (battery_soh,
bms_soh, VPP controls, etc.) to be permanently skipped at setup time.

Fix: track whether at least one poll failed before the first successful
read (_startup_had_offline_poll). On the inverter's first response after
such a cold-start, schedule a config entry reload so all platforms re-run
their setup with real live data. The reload fires at most once per session
and only when the inverter was genuinely offline at startup.

https://claude.ai/code/session_01YHxVdpH5GoadTbaBHuZWoM