### PR TITLE
v0.7.5 - Extract SPE_OFFGRID_SENSORS constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Growatt Modbus Integration for Home Assistant ☀️
 
 ![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange.svg)
-![Version](https://img.shields.io/badge/Version-0.7.5-blue.svg)
+![Version](https://img.shields.io/badge/Version-0.7.6-blue.svg)
 [![GitHub Issues](https://img.shields.io/github/issues/0xAHA/Growatt_ModbusTCP.svg)](https://github.com/0xAHA/Growatt_ModbusTCP/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/0xAHA/Growatt_ModbusTCP.svg?style=social)](https://github.com/0xAHA/Growatt_ModbusTCP)
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,24 @@
 
 ---
 
+## v0.7.6
+
+---
+
+- **Refactor: Extract SPE_OFFGRID_SENSORS constant (phase 1 of architecture review):**
+  The `spe_8000_12000_es` profile previously used an anonymous inline sensor set for its
+  SPF-compatible sensors. This meant any future change to `SPF_OFFGRID_SENSORS` would
+  silently not apply to SPE, making the divergence invisible at review time. Extracted to a
+  named `SPE_OFFGRID_SENSORS` constant with comments documenting which SPF sensors are
+  excluded and why (register overflow, no generator input, remapped registers). No runtime
+  behaviour change — the resolved sensor set is identical to before.
+
+- **Audit: SPA duplicate profile key (architecture review Concern C):**
+  Confirmed `spa_3000_6000_tl_bl` has a single entry in `INVERTER_PROFILES`. Concern C
+  from the architecture review is not present in the current codebase.
+
+---
+
 ## v0.7.5
 
 - **Fix: SPH-TL3 `ac_power_s` and `ac_power_t` always showing 0 (Issue #265):**

--- a/custom_components/growatt_modbus/device_profiles.py
+++ b/custom_components/growatt_modbus/device_profiles.py
@@ -114,6 +114,25 @@ SPF_OFFGRID_SENSORS: Set[str] = {
     "dcdc_temp", "buck1_temp", "buck2_temp",
 }
 
+SPE_OFFGRID_SENSORS: Set[str] = {
+    # SPF-compatible sensors confirmed working on SPE 8000-12000 ES.
+    # Subset of SPF_OFFGRID_SENSORS — excluded sensors documented below.
+    "load_percentage",           # reg 27
+    "ac_apparent_power",         # regs 11/12
+    "grid_voltage",              # reg 20
+    "grid_frequency",            # reg 21
+    "ac_discharge_energy_today", # regs 64/65 (= grid import today on SPE)
+    "mppt_fan_speed",            # reg 81
+    "inverter_fan_speed",        # reg 82
+    "dcdc_temp",                 # reg 26
+    "buck1_temp",                # reg 32
+    "buck2_temp",                # reg 33
+    # ac_input_power excluded    — regs 36/37 produce 429GW overflow on SPE
+    # ac_charge_energy_today excluded — not supported on SPE
+    # generator_* excluded       — SPE has no generator input
+    # op_discharge_* excluded    — remapped to load_energy_* in SPE profile
+}
+
 WIT_EXTRA_SENSORS: Set[str] = {
     # Extra/parallel inverter output (multi-inverter systems)
     "extra_power_to_grid",
@@ -717,22 +736,7 @@ INVERTER_PROFILES = {
             BATTERY_SENSORS |            # includes ac_discharge_energy_total (reg 66/67 = grid import total)
             TEMPERATURE_SENSORS |
             STATUS_SENSORS |
-            {
-                # SPF-compatible sensors confirmed working on SPE
-                "load_percentage",        # reg 27
-                "ac_apparent_power",      # regs 11/12
-                "grid_voltage",           # reg 20
-                "grid_frequency",         # reg 21
-                "ac_discharge_energy_today",  # regs 64/65 = grid import today on SPE
-                "mppt_fan_speed",         # reg 81
-                "inverter_fan_speed",     # reg 82
-                "dcdc_temp",              # reg 26
-                "buck1_temp",             # reg 32
-                "buck2_temp",             # reg 33
-                # ac_input_power excluded — regs 36/37 produce 429GW overflow on SPE
-                # generator_* excluded — SPE has no generator input
-                # op_discharge_energy_today/total excluded — remapped to load_energy_* in profile
-            }
+            SPE_OFFGRID_SENSORS
         ),
     },
 

--- a/custom_components/growatt_modbus/manifest.json
+++ b/custom_components/growatt_modbus/manifest.json
@@ -12,5 +12,5 @@
     "pymodbus>=3.0.0",
     "pyserial>=3.4"
   ],
-  "version": "0.7.5"
+  "version": "0.7.6"
 }


### PR DESCRIPTION
## Summary

- Extracts the anonymous inline sensor set from `spe_8000_12000_es` into a named `SPE_OFFGRID_SENSORS` constant in [device_profiles.py](custom_components/growatt_modbus/device_profiles.py)
- The constant sits alongside `SPF_OFFGRID_SENSORS` with inline comments documenting which SPF sensors are excluded from SPE and why (register overflow, no generator input, remapped registers)
- Confirms `spa_3000_6000_tl_bl` has a single entry in `INVERTER_PROFILES` — architecture review Concern C is not present in the current codebase
- Bumps version to v0.7.5

## Why

Future changes to `SPF_OFFGRID_SENSORS` would silently not apply to SPE because the inline set is invisible to a reviewer scanning the sensor group constants. The named constant closes that maintenance gap.

No runtime behaviour change — the resolved sensor set is byte-for-byte identical to before.

## Test plan

- [ ] Verify `spe_8000_12000_es` profile still loads without error in HA
- [ ] Confirm SPE sensor set is unchanged (10 sensors from `SPE_OFFGRID_SENSORS` plus the base groups)
- [ ] Python syntax check: `python -m py_compile custom_components/growatt_modbus/device_profiles.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)