### PR TITLE
v0.7.7 - Composite sensor group constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Growatt Modbus Integration for Home Assistant ☀️
 
 ![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange.svg)
-![Version](https://img.shields.io/badge/Version-0.7.6-blue.svg)
+![Version](https://img.shields.io/badge/Version-0.7.7-blue.svg)
 [![GitHub Issues](https://img.shields.io/github/issues/0xAHA/Growatt_ModbusTCP.svg)](https://github.com/0xAHA/Growatt_ModbusTCP/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/0xAHA/Growatt_ModbusTCP.svg?style=social)](https://github.com/0xAHA/Growatt_ModbusTCP)
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,28 @@
 
 ---
 
+## v0.7.7
+
+---
+
+- **Refactor: Composite sensor group constants (phase 1 of architecture review):**
+  17 of 28 inverter profiles previously repeated identical 10–13 line sensor union
+  expressions verbatim. Three composite constants now capture the common patterns:
+
+  - `GRID_TIED_1P_SENSORS` — single-phase grid-tied base (no battery); used by MIN profiles
+  - `HYBRID_1P_SENSORS` — `GRID_TIED_1P_SENSORS | BATTERY_SENSORS`; used by SPH and TL-XH
+  - `HYBRID_3P_SENSORS` — same scope as `HYBRID_1P_SENSORS` with `THREE_PHASE_SENSORS`
+    replacing `BASIC_AC_SENSORS`; used by SPH-TL3 and MOD-XH
+
+  Profile compositions now read as single expressions, e.g. `HYBRID_1P_SENSORS | PV3_SENSORS`
+  instead of a 12-line union. Adding a sensor to a shared cluster is now one line instead of
+  up to 8. No entity IDs, sensor keys, or runtime behaviour changed — the resolved sets are
+  identical to before. 11 profiles with unique compositions are left as explicit inline blocks.
+
+  Net change: −201 lines in `device_profiles.py`.
+
+---
+
 ## v0.7.6
 
 ---

--- a/custom_components/growatt_modbus/device_profiles.py
+++ b/custom_components/growatt_modbus/device_profiles.py
@@ -141,6 +141,36 @@ WIT_EXTRA_SENSORS: Set[str] = {
 
 
 # ============================================================================
+# COMPOSITE SENSOR GROUPS
+# Convenience unions used by INVERTER_PROFILES below.
+# No new sensor keys are defined here — these only combine existing groups.
+# ============================================================================
+
+# Single-phase grid-tied base (no battery): PV + AC output + grid + energy breakdown.
+# Used by MIN string inverter profiles; serves as the no-battery 1-phase baseline.
+GRID_TIED_1P_SENSORS: Set[str] = (
+    BASIC_PV_SENSORS | BASIC_AC_SENSORS | GRID_SENSORS | POWER_FLOW_SENSORS
+    | CONSUMPTION_SENSORS | ENERGY_SENSORS | PV_DC_ENERGY_SENSORS
+    | PV_MPPT_TOTAL_SENSORS | ENERGY_BREAKDOWN_SENSORS
+    | TEMPERATURE_SENSORS | STATUS_SENSORS
+)
+
+# Single-phase hybrid: grid-tied base + battery storage.
+# Used by SPH and TL-XH hybrid profiles.
+HYBRID_1P_SENSORS: Set[str] = GRID_TIED_1P_SENSORS | BATTERY_SENSORS
+
+# Three-phase hybrid: same capability scope as HYBRID_1P_SENSORS with
+# THREE_PHASE_SENSORS replacing BASIC_AC_SENSORS.
+# Used by SPH-TL3 and MOD-XH hybrid profiles.
+HYBRID_3P_SENSORS: Set[str] = (
+    BASIC_PV_SENSORS | THREE_PHASE_SENSORS | GRID_SENSORS | POWER_FLOW_SENSORS
+    | CONSUMPTION_SENSORS | ENERGY_SENSORS | PV_DC_ENERGY_SENSORS
+    | PV_MPPT_TOTAL_SENSORS | ENERGY_BREAKDOWN_SENSORS | BATTERY_SENSORS
+    | TEMPERATURE_SENSORS | STATUS_SENSORS
+)
+
+
+# ============================================================================
 # INVERTER PROFILES
 # ============================================================================
 
@@ -221,19 +251,7 @@ INVERTER_PROFILES = {
         "has_battery": False,
         "max_power_kw": 6.0,
         "protocol_version": "v1.39",
-        "sensors": (
-            BASIC_PV_SENSORS |
-            BASIC_AC_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": GRID_TIED_1P_SENSORS,
     },
 
     "min_7000_10000_tl_x": {
@@ -245,21 +263,7 @@ INVERTER_PROFILES = {
         "has_battery": False,
         "max_power_kw": 10.0,
         "protocol_version": "v1.39",
-        "sensors": (
-            BASIC_PV_SENSORS |
-            PV3_SENSORS |
-            BASIC_AC_SENSORS |
-            SYSTEM_OUTPUT_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": GRID_TIED_1P_SENSORS | PV3_SENSORS | SYSTEM_OUTPUT_SENSORS,
     },
 
     # MIN Series VPP Protocol V2.01 (adds 30000 range for DTC)
@@ -272,19 +276,7 @@ INVERTER_PROFILES = {
         "has_battery": False,
         "max_power_kw": 6.0,
         "protocol_version": "v2.01",
-        "sensors": (
-            BASIC_PV_SENSORS |
-            BASIC_AC_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": GRID_TIED_1P_SENSORS,
     },
 
     "min_7000_10000_tl_x_v201": {
@@ -296,21 +288,7 @@ INVERTER_PROFILES = {
         "has_battery": False,
         "max_power_kw": 10.0,
         "protocol_version": "v2.01",
-        "sensors": (
-            BASIC_PV_SENSORS |
-            PV3_SENSORS |
-            BASIC_AC_SENSORS |
-            SYSTEM_OUTPUT_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": GRID_TIED_1P_SENSORS | PV3_SENSORS | SYSTEM_OUTPUT_SENSORS,
     },
 
     # ========================================================================
@@ -325,21 +303,7 @@ INVERTER_PROFILES = {
         "has_pv3": True,
         "has_battery": True,
         "max_power_kw": 10.0,
-        "sensors": (
-            BASIC_PV_SENSORS |
-            PV3_SENSORS |
-            BASIC_AC_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_1P_SENSORS | PV3_SENSORS,
     },
     
     "tl_xh_us_3000_10000": {
@@ -350,21 +314,7 @@ INVERTER_PROFILES = {
         "has_pv3": True,
         "has_battery": True,
         "max_power_kw": 10.0,
-        "sensors": (
-            BASIC_PV_SENSORS |
-            PV3_SENSORS |
-            BASIC_AC_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_1P_SENSORS | PV3_SENSORS,
     },
 
     # TL-XH V2.01 VPP Protocol
@@ -377,21 +327,7 @@ INVERTER_PROFILES = {
         "has_battery": True,
         "max_power_kw": 10.0,
         "protocol_version": "v2.01",
-        "sensors": (
-            BASIC_PV_SENSORS |
-            PV3_SENSORS |
-            BASIC_AC_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_1P_SENSORS | PV3_SENSORS,
     },
 
     "tl_xh_us_3000_10000_v201": {
@@ -403,21 +339,7 @@ INVERTER_PROFILES = {
         "has_battery": True,
         "max_power_kw": 10.0,
         "protocol_version": "v2.01",
-        "sensors": (
-            BASIC_PV_SENSORS |
-            PV3_SENSORS |
-            BASIC_AC_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_1P_SENSORS | PV3_SENSORS,
     },
 
     # MIN TL-XH Hybrid - Uses MIN 3000+ range with VPP battery
@@ -501,20 +423,7 @@ INVERTER_PROFILES = {
         "has_pv3": False,
         "has_battery": True,
         "max_power_kw": 6.0,
-        "sensors": (
-            BASIC_PV_SENSORS |
-            BASIC_AC_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_1P_SENSORS,
     },
     
     "sph_7000_10000": {
@@ -525,21 +434,7 @@ INVERTER_PROFILES = {
         "has_pv3": True,  # 7-10kW models have 3 PV strings (registers 11-14)
         "has_battery": True,
         "max_power_kw": 10.0,
-        "sensors": (
-            BASIC_PV_SENSORS |
-            PV3_SENSORS |  # 7-10kW models have 3 PV strings
-            BASIC_AC_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_1P_SENSORS | PV3_SENSORS,
     },
 
     "sph_8000_10000_hu": {
@@ -550,22 +445,7 @@ INVERTER_PROFILES = {
         "has_pv3": True,
         "has_battery": True,
         "max_power_kw": 10.0,
-        "sensors": (
-            BASIC_PV_SENSORS |
-            PV3_SENSORS |
-            BASIC_AC_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            BMS_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_1P_SENSORS | PV3_SENSORS | BMS_SENSORS,
     },
 
     # SPH V2.01 VPP Protocol
@@ -578,20 +458,7 @@ INVERTER_PROFILES = {
         "has_battery": True,
         "max_power_kw": 6.0,
         "protocol_version": "v2.01",
-        "sensors": (
-            BASIC_PV_SENSORS |
-            BASIC_AC_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_1P_SENSORS,
     },
 
     "sph_7000_10000_v201": {
@@ -603,21 +470,7 @@ INVERTER_PROFILES = {
         "has_battery": True,
         "max_power_kw": 10.0,
         "protocol_version": "v2.01",
-        "sensors": (
-            BASIC_PV_SENSORS |
-            PV3_SENSORS |  # 7-10kW models have 3 PV strings
-            BASIC_AC_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_1P_SENSORS | PV3_SENSORS,
     },
 
     # ========================================================================
@@ -632,20 +485,7 @@ INVERTER_PROFILES = {
         "has_pv3": False,
         "has_battery": True,
         "max_power_kw": 10.0,
-        "sensors": (
-            BASIC_PV_SENSORS |
-            THREE_PHASE_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_3P_SENSORS,
     },
 
     # SPH-TL3 V2.01 VPP Protocol
@@ -658,20 +498,7 @@ INVERTER_PROFILES = {
         "has_battery": True,
         "max_power_kw": 10.0,
         "protocol_version": "v2.01",
-        "sensors": (
-            BASIC_PV_SENSORS |
-            THREE_PHASE_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_3P_SENSORS,
     },
 
     # ========================================================================
@@ -772,21 +599,7 @@ INVERTER_PROFILES = {
         "has_pv3": True,
         "has_battery": True,
         "max_power_kw": 15.0,
-        "sensors": (
-            BASIC_PV_SENSORS |
-            PV3_SENSORS |
-            THREE_PHASE_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_3P_SENSORS | PV3_SENSORS,
     },
 
     "mod_6000_15000tl3_xh_v201": {
@@ -798,21 +611,7 @@ INVERTER_PROFILES = {
         "has_pv3": True,
         "has_battery": True,
         "max_power_kw": 15.0,
-        "sensors": (
-            BASIC_PV_SENSORS |
-            PV3_SENSORS |
-            THREE_PHASE_SENSORS |
-            GRID_SENSORS |
-            POWER_FLOW_SENSORS |
-            CONSUMPTION_SENSORS |
-            ENERGY_SENSORS |
-            PV_DC_ENERGY_SENSORS |
-            PV_MPPT_TOTAL_SENSORS |
-            ENERGY_BREAKDOWN_SENSORS |
-            BATTERY_SENSORS |
-            TEMPERATURE_SENSORS |
-            STATUS_SENSORS
-        ),
+        "sensors": HYBRID_3P_SENSORS | PV3_SENSORS,
     },
 
     # ========================================================================

--- a/custom_components/growatt_modbus/manifest.json
+++ b/custom_components/growatt_modbus/manifest.json
@@ -12,5 +12,5 @@
     "pymodbus>=3.0.0",
     "pyserial>=3.4"
   ],
-  "version": "0.7.6"
+  "version": "0.7.7"
 }


### PR DESCRIPTION
## Summary

- Adds three composite constants to [device_profiles.py](custom_components/growatt_modbus/device_profiles.py) that capture the repeating sensor union patterns across profiles:
  - `GRID_TIED_1P_SENSORS` — single-phase grid-tied base (no battery); MIN profiles
  - `HYBRID_1P_SENSORS` — `GRID_TIED_1P_SENSORS | BATTERY_SENSORS`; SPH and TL-XH
  - `HYBRID_3P_SENSORS` — same scope as `HYBRID_1P_SENSORS` with `THREE_PHASE_SENSORS` replacing `BASIC_AC_SENSORS`; SPH-TL3 and MOD-XH
- Reduces 17 of 28 profile sensor compositions from 10–13 line unions to single-line expressions
- 11 profiles with unique compositions (MIC, MID, SPA, SPF, SPE, MOD grid-tied, MIN TL-XH, WIT) are left as explicit inline blocks
- Net: **−201 lines** in `device_profiles.py`

## Why

Adding a sensor to a shared capability cluster previously required editing up to 8 identical blocks. It was also impossible to tell at a glance whether two profiles had the same composition or subtly differed. The composite constants make structure visible and maintenance changes a one-line edit.

Phase 1, item 10b from the consolidated architecture review — identified as highest-priority, lowest-risk by all three review passes.

## Safety

Pure constant extraction. The set union at module load time produces values byte-for-byte identical to the previous inline expressions. No entity IDs, sensor keys, coordinator logic, or HA config entries are affected.

## Test plan

- [ ] `python -m py_compile custom_components/growatt_modbus/device_profiles.py` passes ✅
- [ ] Verify sensor counts unchanged for at least one SPH, one MIN, one TL-XH, one SPH-TL3, and one MOD-XH profile
- [ ] Load integration in HA and confirm no entities disappear or change

🤖 Generated with [Claude Code](https://claude.com/claude-code)