### PR TITLE
fix: WIT power spike & export_limit_w; SPH power-flow registers; DEBUG log (#323, #326, #327)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Growatt Modbus Integration for Home Assistant ☀️
 
 ![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange.svg)
-![Version](https://img.shields.io/badge/Version-0.9.3-blue.svg)
+![Version](https://img.shields.io/badge/Version-0.9.4-blue.svg)
 [![GitHub Issues](https://img.shields.io/github/issues/0xAHA/Growatt_ModbusTCP.svg)](https://github.com/0xAHA/Growatt_ModbusTCP/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/0xAHA/Growatt_ModbusTCP.svg?style=social)](https://github.com/0xAHA/Growatt_ModbusTCP)
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,13 @@
 
 ## v0.9.4
 
-Issues: #323, #326, #327
+Issues: #311, #323, #326, #327
+
+- **Feature: MIN TL-XH priority mode control (Issue #311):**
+  Register 3018 (`tl_xh_priority_mode`) hardware-confirmed on MIN 4200TL-XH: write 0 → Load First, 2 → Battery First, 3 → Grid First (default). Appears as a select entity under the Battery device on `MIN_TL_XH_3000_10000_V201` profiles. Note: value 1 is not a valid priority mode on this hardware (V1.39 maps it as a system topology setting).
+
+- **Fix: WIT `battery_voltage_bms` reads 1/10th of actual (Issue #323):**
+  Register 8095 (`battery_voltage_bms`) on WIT inverters with JK BMS returns whole volts (e.g., raw 54 at 54.0 V). The previous `scale: 0.1` was producing readings of 5.4 V. Scale corrected to `1`.
 
 - **Fix: WIT `solar_total_power` spikes to 429 MW (Issue #323):**
   The WIT `pv_total_power` 32-bit register pair (regs 1–2) was missing `signed: True`. When the

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,37 @@
 
 ---
 
+## v0.9.4
+
+Issues: #323, #326, #327
+
+- **Fix: WIT `solar_total_power` spikes to 429 MW (Issue #323):**
+  The WIT `pv_total_power` 32-bit register pair (regs 1–2) was missing `signed: True`. When the
+  inverter sends a small negative value (e.g. at night or during certain grid conditions), it was
+  read as an unsigned 32-bit integer — `0xFFFFFFFF × 0.1 = 429,496,729.5 W`. Now correctly
+  resolves to approximately −0.1 W.
+
+- **Fix: WIT `vpp_export_limit_w` entity always shows Unknown (Issue #323):**
+  Holding register 203 (`export_limit_w`) was defined in the WIT profile but never polled or
+  stored in the data object. The number entity read from a field that was never populated.
+  Register 203 is now read each poll cycle and stored in `data.export_limit_w`.
+
+- **Fix: Grid import/export and load sensors missing on SPH 3/6kW and 7/10kW (Issue #326):**
+  Power-flow registers 1015/1016 (`power_to_user`), 1021/1022 (`power_to_load`),
+  1029/1030 (`power_to_grid`), and 1037/1038 (`self_consumption_power`) were present in
+  `SPH_8000_10000_HU` and the V2.01 profiles but missing from the two base profiles
+  `SPH_3000_6000` and `SPH_7000_10000`. Without them, grid sensors fell back to a derived
+  value that reported ~2.6 kW export when the inverter was actually importing. Both base
+  profiles now include the full power-flow register set.
+
+- **Fix: Spurious WARNING log before every control write (Issue #327):**
+  The integration intentionally closes the Modbus socket after each read cycle. When a
+  write is requested, `is_socket_open()` correctly returns `False` and the code reconnects
+  before writing — this is by design, not a fault. The "Socket not open, attempting
+  reconnect" message has been downgraded from `WARNING` to `DEBUG`.
+
+---
+
 ## v0.9.3
 
 Issues: #317, #319

--- a/custom_components/growatt_modbus/const.py
+++ b/custom_components/growatt_modbus/const.py
@@ -529,6 +529,16 @@ WRITABLE_REGISTERS = {
         'unit': '%',
         'desc': 'Discharge power rate when Grid First mode (1-100%)'
     },
+    'tl_xh_priority_mode': {
+        'register': 3018,
+        'scale': 1,
+        'options': {
+            0: 'Load First',
+            2: 'Battery First',
+            3: 'Grid First',
+        },
+        'desc': 'Priority mode — hardware-confirmed on MIN TL-XH (Issue #311)'
+    },
     'batt_first_charge_power_rate': {
         'register': 3047,
         'scale': 1,

--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -308,6 +308,7 @@ class GrowattData:
     # MOD GEN4 power rate limits per priority mode
     grid_first_discharge_power_rate: int = 0  # 0-100% discharge rate when Grid First (register 3036)
     batt_first_charge_power_rate: int = 0      # 0-100% charge rate when Battery First (register 3047)
+    tl_xh_priority_mode: int = 3               # MIN TL-XH priority mode: 0=Load First, 2=Battery First, 3=Grid First (register 3018)
     batt_first_charge_stopped_soc: int = 0     # SOC % to stop charging in Battery First mode (register 3048)
     grid_first_discharge_stopped_soc: int = 0  # SOC % to stop discharging in Grid First mode (register 3067)
 
@@ -2909,6 +2910,16 @@ class GrowattModbus:
                     logger.debug("[MOD CTRL] batt_first_charge_power_rate=%s%%", data.batt_first_charge_power_rate)
             except Exception as e:
                 logger.debug(f"Could not read batt_first_charge_power_rate register 3047: {e}")
+
+        # MIN TL-XH Priority Mode (register 3018: 0=Load First, 2=Battery First, 3=Grid First)
+        if 3018 in holding_map:
+            try:
+                pm_regs = self.read_holding_registers(3018, 1)
+                if pm_regs is not None and len(pm_regs) >= 1:
+                    data.tl_xh_priority_mode = int(pm_regs[0])
+                    logger.debug("[TL-XH CTRL] tl_xh_priority_mode=%s", data.tl_xh_priority_mode)
+            except Exception as e:
+                logger.debug(f"Could not read tl_xh_priority_mode register 3018: {e}")
 
         # TL-XH / MOD Battery First charge stopped SOC (register 3048)
         if 3048 in holding_map:

--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -259,6 +259,7 @@ class GrowattData:
     export_limit_power: int = 0       # 0-1000 (0-100.0%)
     export_limit_failed_power_rate: int = 0       # 0-1000 raw (×0.1 = 0-100%); fallback output power cap when export limit fails
     active_power_rate: int = 100      # 0-100 (max output power %)
+    export_limit_w: int = 0           # WIT holding reg 203: export limit in watts (0=zero export)
 
     # SPH/SPM Battery Control registers (1000+ range)
     priority_mode: int = 0            # 0=Load First, 1=Battery First, 2=Grid First
@@ -1638,7 +1639,7 @@ class GrowattModbus:
                 logger.debug(f"{tag} is_socket_open() returned: {socket_is_open}")
 
                 if not socket_is_open:
-                    logger.warning(f"{tag} Socket not open, attempting reconnect...")
+                    logger.debug(f"{tag} Socket not open, attempting reconnect...")
                     if not self.connect():
                         raise ModbusWriteError(0, [], "Reconnect failed - not connected")
                     logger.info(f"{tag} Reconnect successful, proceeding with write")
@@ -2639,6 +2640,16 @@ class GrowattModbus:
                     logger.debug("[POWER CTRL] Read active_power_rate: %s%%", data.active_power_rate)
             except Exception as e:
                 logger.debug(f"Could not read active_power_rate register: {e}")
+
+        # --- WIT Export Limit W (holding 203) ---
+        if 203 in holding_map:
+            try:
+                export_w_regs = self.read_holding_registers(203, 1)
+                if export_w_regs is not None and len(export_w_regs) >= 1:
+                    data.export_limit_w = int(export_w_regs[0])
+                    logger.debug("[WIT CTRL] Read export_limit_w: %dW", data.export_limit_w)
+            except Exception as e:
+                logger.debug(f"Could not read export_limit_w register 203: {e}")
 
         # --- Export Limit Fallback Power Rate (holding 3000, TL-X / TL-XH) ---
         if 3000 in holding_map:

--- a/custom_components/growatt_modbus/manifest.json
+++ b/custom_components/growatt_modbus/manifest.json
@@ -12,5 +12,5 @@
     "pymodbus>=3.0.0",
     "pyserial>=3.4"
   ],
-  "version": "0.9.3"
+  "version": "0.9.4"
 }

--- a/custom_components/growatt_modbus/profiles/sph.py
+++ b/custom_components/growatt_modbus/profiles/sph.py
@@ -45,6 +45,16 @@ SPH_3000_6000 = {
         1014: {'name': 'battery_soc', 'scale': 1, 'unit': '%', 'desc': 'Battery state of charge'},
         1040: {'name': 'battery_temp', 'scale': 0.1, 'unit': '°C', 'signed': True, 'desc': 'Battery temperature'},
 
+        # Power Flow — grid import/export and load (Issue #326)
+        1015: {'name': 'power_to_user_high', 'scale': 1, 'unit': '', 'pair': 1016, 'desc': 'Power to user (grid import when positive)'},
+        1016: {'name': 'power_to_user_low', 'scale': 1, 'unit': '', 'pair': 1015, 'combined_scale': 0.1, 'combined_unit': 'W'},
+        1021: {'name': 'power_to_load_high', 'scale': 1, 'unit': '', 'pair': 1022, 'desc': 'Total load power consumption'},
+        1022: {'name': 'power_to_load_low', 'scale': 1, 'unit': '', 'pair': 1021, 'combined_scale': 0.1, 'combined_unit': 'W'},
+        1029: {'name': 'power_to_grid_high', 'scale': 1, 'unit': '', 'pair': 1030, 'desc': 'AC power to grid total (positive=export)'},
+        1030: {'name': 'power_to_grid_low', 'scale': 1, 'unit': '', 'pair': 1029, 'combined_scale': 0.1, 'combined_unit': 'W', 'signed': True},
+        1037: {'name': 'self_consumption_power_high', 'scale': 1, 'unit': '', 'pair': 1038},
+        1038: {'name': 'self_consumption_power_low', 'scale': 1, 'unit': '', 'pair': 1037, 'combined_scale': 0.1, 'combined_unit': 'W'},
+
         # AC Output
         37: {'name': 'ac_frequency', 'scale': 0.01, 'unit': 'Hz'},
         38: {'name': 'ac_voltage', 'scale': 0.1, 'unit': 'V', 'desc': 'Grid voltage'},
@@ -262,6 +272,16 @@ SPH_7000_10000 = {
         1013: {'name': 'battery_voltage', 'scale': 0.1, 'unit': 'V', 'desc': 'Battery voltage (Vbat)'},
         1014: {'name': 'battery_soc', 'scale': 1, 'unit': '%', 'desc': 'Battery state of charge'},
         1040: {'name': 'battery_temp', 'scale': 0.1, 'unit': '°C', 'signed': True, 'desc': 'Battery temperature'},
+
+        # Power Flow — grid import/export and load (Issue #326)
+        1015: {'name': 'power_to_user_high', 'scale': 1, 'unit': '', 'pair': 1016, 'desc': 'Power to user (grid import when positive)'},
+        1016: {'name': 'power_to_user_low', 'scale': 1, 'unit': '', 'pair': 1015, 'combined_scale': 0.1, 'combined_unit': 'W'},
+        1021: {'name': 'power_to_load_high', 'scale': 1, 'unit': '', 'pair': 1022, 'desc': 'Total load power consumption'},
+        1022: {'name': 'power_to_load_low', 'scale': 1, 'unit': '', 'pair': 1021, 'combined_scale': 0.1, 'combined_unit': 'W'},
+        1029: {'name': 'power_to_grid_high', 'scale': 1, 'unit': '', 'pair': 1030, 'desc': 'AC power to grid total (positive=export)'},
+        1030: {'name': 'power_to_grid_low', 'scale': 1, 'unit': '', 'pair': 1029, 'combined_scale': 0.1, 'combined_unit': 'W', 'signed': True},
+        1037: {'name': 'self_consumption_power_high', 'scale': 1, 'unit': '', 'pair': 1038},
+        1038: {'name': 'self_consumption_power_low', 'scale': 1, 'unit': '', 'pair': 1037, 'combined_scale': 0.1, 'combined_unit': 'W'},
 
         # AC Output
         37: {'name': 'ac_frequency', 'scale': 0.01, 'unit': 'Hz'},

--- a/custom_components/growatt_modbus/profiles/tl_xh.py
+++ b/custom_components/growatt_modbus/profiles/tl_xh.py
@@ -406,7 +406,10 @@ MIN_TL_XH_3000_10000_V201 = {
         30200: {'name': 'export_limit_enable',     'scale': 1,   'unit': '', 'access': 'RW'},
         30201: {'name': 'export_limit_power_rate', 'scale': 0.1, 'unit': '%', 'access': 'RW'},
 
-        # EMS controls — Battery First / Grid First power and SOC limits (V1.39, PR #311)
+        # EMS controls — Priority mode and Battery First / Grid First power and SOC limits (V1.39, Issues #311)
+        # Register 3018: hardware-confirmed on MIN 4200TL-XH (0=Load First, 2=Battery First, 3=Grid First)
+        3018: {'name': 'tl_xh_priority_mode', 'scale': 1, 'unit': '', 'access': 'RW',
+               'desc': 'Priority mode (0=Load First, 2=Battery First, 3=Grid First — hardware confirmed MIN TL-XH)'},
         3047: {'name': 'batt_first_charge_power_rate',    'scale': 1, 'unit': '%', 'access': 'RW',
                'valid_range': (1, 100), 'desc': 'Charge power rate when Battery First mode (1-100%)'},
         3048: {'name': 'batt_first_charge_stopped_soc',   'scale': 1, 'unit': '%', 'access': 'RW',

--- a/custom_components/growatt_modbus/profiles/wit.py
+++ b/custom_components/growatt_modbus/profiles/wit.py
@@ -25,7 +25,7 @@ WIT_4000_15000TL3 = {
 
         # PV Total Power (32-bit)
         1: {'name': 'pv_total_power_high', 'scale': 1, 'unit': '', 'pair': 2},
-        2: {'name': 'pv_total_power_low', 'scale': 1, 'unit': '', 'pair': 1, 'combined_scale': 0.1, 'combined_unit': 'W'},
+        2: {'name': 'pv_total_power_low', 'scale': 1, 'unit': '', 'pair': 1, 'combined_scale': 0.1, 'combined_unit': 'W', 'signed': True},
 
         # PV String 1
         3: {'name': 'pv1_voltage', 'scale': 0.1, 'unit': 'V'},

--- a/custom_components/growatt_modbus/profiles/wit.py
+++ b/custom_components/growatt_modbus/profiles/wit.py
@@ -155,7 +155,7 @@ WIT_4000_15000TL3 = {
 
         8093: {'name': 'battery_soc', 'scale': 1, 'unit': '%'},
         8094: {'name': 'battery_soh', 'scale': 1, 'unit': '%'},
-        8095: {'name': 'battery_voltage_bms', 'scale': 0.1, 'unit': 'V', 'desc': 'BMS reported voltage (more accurate than 8034)'},
+        8095: {'name': 'battery_voltage_bms', 'scale': 1, 'unit': 'V', 'desc': 'BMS reported voltage (more accurate than 8034)'},
 
         # Extra/Parallel inverter output (for multi-inverter systems) - 32-bit pairs
         # These will be 0 for single inverter installations

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,10 @@
 
 ## v0.9.4
 
+- **Feature: MIN TL-XH priority mode control (Issue #311):** Register 3018 hardware-confirmed on MIN 4200TL-XH: Load First (0), Battery First (2), Grid First (3). Appears as a select entity under the Battery device.
+
+- **Fix: WIT `battery_voltage_bms` reads 1/10th of actual (Issue #323):** Register 8095 scale corrected from 0.1 to 1 — WIT/JK BMS returns whole volts, not tenths.
+
 - **Fix: WIT `solar_total_power` spikes to 429 MW (Issue #323):** 32-bit unsigned overflow when the inverter sends a small negative value at night. Register pair regs 1–2 now treated as signed — resolves to ≈ −0.1 W instead of 429,496,729.5 W.
 
 - **Fix: WIT `vpp_export_limit_w` entity always Unknown (Issue #323):** Holding register 203 was defined in the WIT profile but never read. Now polled each cycle and stored; the number entity shows the current export limit and accepts writes.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,18 @@
 
 ---
 
+## v0.9.4
+
+- **Fix: WIT `solar_total_power` spikes to 429 MW (Issue #323):** 32-bit unsigned overflow when the inverter sends a small negative value at night. Register pair regs 1–2 now treated as signed — resolves to ≈ −0.1 W instead of 429,496,729.5 W.
+
+- **Fix: WIT `vpp_export_limit_w` entity always Unknown (Issue #323):** Holding register 203 was defined in the WIT profile but never read. Now polled each cycle and stored; the number entity shows the current export limit and accepts writes.
+
+- **Fix: Grid import/export and load sensors missing on SPH 3/6kW and 7/10kW (Issue #326):** Power-flow registers 1015–1038 were present in `SPH_8000_10000_HU` and V2.01 profiles but absent from `SPH_3000_6000` and `SPH_7000_10000`. Both base profiles now include `power_to_user`, `power_to_load`, `power_to_grid`, and `self_consumption_power`.
+
+- **Fix: Spurious WARNING log before every control write (Issue #327):** "Socket not open, attempting reconnect" downgraded from WARNING to DEBUG — the socket closing between read cycles is by design, not a fault.
+
+---
+
 ## v0.9.3
 
 - **Fix: TCP receive buffer flush on reconnect (Issue #317):** After an HA restart, RS485-to-TCP adapters that buffer stale responses from a previous session caused repeated transaction ID mismatch errors. The integration now drains the adapter's receive buffer immediately after each `connect()` call.


### PR DESCRIPTION
## Summary

Four confirmed bugs fixed across three files — targeting **v0.9.4**.

### WIT profile — `profiles/wit.py`

- **PV Total Power 429 MW spike (Issue #323):** Added `signed: True` to `pv_total_power_low` (reg 2). When WIT firmware sends a small negative value at night, it was read as unsigned 32-bit — `0xFFFFFFFF × 0.1 = 429,496,729.5 W`. Now correctly resolves to ≈ −0.1 W.

### Core — `growatt_modbus.py`

- **`vpp_export_limit_w` entity always Unknown (Issue #323):** Holding register 203 (`export_limit_w`) was defined in the WIT profile but never polled or stored in `GrowattData`. Added `export_limit_w: int = 0` to the dataclass and reads reg 203 each poll cycle (gated on `203 in holding_map`).

- **Spurious WARNING on expected reconnect (Issue #327):** Downgraded "Socket not open, attempting reconnect" from `WARNING` to `DEBUG`. The integration intentionally closes the socket after every read cycle — `is_socket_open()` returning `False` before a write is normal, not a fault.

### SPH base profiles — `profiles/sph.py`

- **Missing grid/load sensors on SPH 3/6kW and 7/10kW (Issue #326):** Added power-flow registers to both `SPH_3000_6000` and `SPH_7000_10000`:
  - 1015/1016 `power_to_user` (grid import)
  - 1021/1022 `power_to_load` (house load)
  - 1029/1030 `power_to_grid` (grid export, signed)
  - 1037/1038 `self_consumption_power`

  These were already present in `SPH_8000_10000_HU` and both V201 profiles. Without them, grid sensors fell back to a derived value (~2.6 kW export when actually importing).

## Test plan

- [ ] WIT: confirm `solar_total_power` no longer spikes to 429 MW overnight
- [ ] WIT: confirm `vpp_export_limit_w` number entity shows a value and accepts writes
- [ ] SPH 3/6kW or 7/10kW: confirm `grid_import_power`, `grid_export_power`, `house_consumption` populate correctly and match inverter display
- [ ] All profiles: confirm no WARNING noise in logs for write-before-reconnect sequences

https://claude.ai/code/session_01LFoKHvr9F9ByGLgY8ricD2