### PR TITLE
fix: shared TCP connection never recovers from silent connection loss

### DIFF
--- a/custom_components/growatt_modbus/coordinator.py
+++ b/custom_components/growatt_modbus/coordinator.py
@@ -951,6 +951,24 @@ class GrowattModbusCoordinator(DataUpdateCoordinator[GrowattData]):
                 self._client.min_read_interval = delay_s
 
             data = self._client.read_all_data()
+            if data is None:
+                # The connection may be silently dead: pymodbus sync clients never
+                # clear their socket on receive timeouts, so is_socket_open() stays
+                # True and ensure_connected() would reuse the dead socket on every
+                # poll until HA restarts. Force a real reconnect and retry once.
+                hub.reset("poll returned no data")
+                if hub.ensure_connected():
+                    _LOGGER.info(
+                        "Reconnected to %s:%s — retrying poll for slave %s",
+                        self.config.get(CONF_HOST), self.config.get(CONF_PORT),
+                        self.config.get(CONF_SLAVE_ID),
+                    )
+                    data = self._client.read_all_data()
+                    if data is None:
+                        # Still failing — drop the socket so the next scheduled poll
+                        # starts from a clean connect instead of a stale session.
+                        hub.reset("retry poll returned no data")
+
             if data is not None and not self._serial_number:
                 self._read_device_identification()
 
@@ -960,6 +978,7 @@ class GrowattModbusCoordinator(DataUpdateCoordinator[GrowattData]):
         except Exception as err:
             _LOGGER.warning("Error during shared data fetch for slave %s: %s",
                             self.config.get(CONF_SLAVE_ID), err)
+            hub.reset("exception during poll")
             return None
 
         finally:

--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -454,6 +454,21 @@ class SharedModbusConnection:
                 pass
             self._connected = False
 
+    def reset(self, reason: str = "") -> None:
+        """Force-close the socket so the next ensure_connected() does a real reconnect.
+
+        pymodbus sync clients never clear their socket after a silent connection loss
+        (receive timeouts don't trigger close(), and connection_lost() is a no-op for
+        sync clients), so is_socket_open() keeps returning True and ensure_connected()
+        would reuse the dead socket forever. Without this, only an HA restart recovers
+        a wedged connection.
+        """
+        logger.warning(
+            "[SharedConn %s:%s] Resetting connection%s",
+            self.host, self.port, f": {reason}" if reason else "",
+        )
+        self.disconnect()
+
     def _flush_receive_buffer(self) -> None:
         """Drain stale Modbus responses left in the adapter's TCP buffer after reconnect."""
         sock = getattr(self._client, 'socket', None)
@@ -550,6 +565,9 @@ class SharedModbusConnection:
         except Exception as exc:
             logger.debug("[SharedConn %s:%s] write_register(%d, %d, slave=%d) error: %s",
                          self.host, self.port, register, value, slave_id, exc)
+            # An exception here is transport-level (register-level refusals come back
+            # as isError() responses) — drop the socket so the next call reconnects.
+            self.disconnect()
             return False
 
     def write_registers(self, register: int, values: list, slave_id: int) -> bool:
@@ -567,6 +585,9 @@ class SharedModbusConnection:
         except Exception as exc:
             logger.debug("[SharedConn %s:%s] write_registers(%d, slave=%d) error: %s",
                          self.host, self.port, register, slave_id, exc)
+            # An exception here is transport-level (register-level refusals come back
+            # as isError() responses) — drop the socket so the next call reconnects.
+            self.disconnect()
             return False
 
 


### PR DESCRIPTION
After updating to v1.0.11, my setup (WIT 8000TL3-HU over a Wi-Fi Modbus TCP dongle) started hanging: after a silent connection drop the integration stayed offline until I restarted Home Assistant. I dug into why and it turned out to be a recovery gap in the new shared-connection mode, so I'm submitting the fix directly rather than just an issue — hope that's OK.

## Root cause

Since v1.0.8, every TCP entry (including single-inverter setups) goes through `SharedModbusConnection`, whose `ensure_connected()` trusts pymodbus's `is_socket_open()`. Verified against pymodbus 3.9.2 (what current HA ships):

1. `is_socket_open()` is literally `return self.socket is not None` — no liveness probe.
2. The sync client only clears `self.socket` when the peer closes **cleanly** (recv returns empty → `close()`) or on a connect `OSError`.
3. On a **silent** drop (dongle/gateway power blip, Wi-Fi dropout, idle NAT timeout — no FIN/RST reaches HA), reads just time out. `sync_execute()` then calls `connection_lost()` (log text says "CLOSING CONNECTION"), but `connection_lost()` starts with `if not self.transport ...: return` — and **sync clients have no asyncio transport, so it's a no-op**. The socket object survives forever.

So after a silent drop: `ensure_connected()` sees "socket open" → skips reconnect → every read times out → hub swallows the exception and returns `None` → coordinator goes offline (300 s interval) → same dead socket next poll, forever. The pre-v1.0 `_fetch_data()` path self-healed because it did disconnect → fresh connect with retries every poll; in shared mode `GrowattModbus.connect()`/`disconnect()` are no-ops, so no recovery path remained.

**Reproduce:** any TCP entry → power-cycle the gateway (or briefly cut its network) without letting it send FIN/RST → restore it. The integration never comes back; restarting HA fixes it instantly.

## The fix (additive only, 40 lines)

- `SharedModbusConnection.reset()` — force-closes the socket (`client.close()` sets pymodbus's socket to `None`), so the next `ensure_connected()` performs a real reconnect including the stale-buffer flush.
- `_fetch_data_shared()` — when a poll returns no data: reset, reconnect, and retry once within the same poll; if the retry also fails, reset again so the next scheduled poll starts from a clean connect. The exception path also resets.
- Hub `write_register()` / `write_registers()` — drop the socket on transport-level exceptions (register-level refusals still come back as `isError()` responses and are unaffected), so writes self-heal via `ensure_connected()` too.

Running this on my WIT 8000TL3-HU for a couple of days now — silent gateway drops recover within one or two polls (visible as a `[SharedConn ...] Resetting connection` warning), no HA restarts needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
