### PR TITLE
fix: block-level transport-error recovery for shared Modbus connections (#364)

### DIFF
--- a/custom_components/growatt_modbus/coordinator.py
+++ b/custom_components/growatt_modbus/coordinator.py
@@ -984,6 +984,12 @@ class GrowattModbusCoordinator(DataUpdateCoordinator[GrowattData]):
             return None
 
         try:
+            # Issue #364: reset the per-poll transport-error recovery budget before any
+            # reads happen, so block-level reset+retry (read_input_registers /
+            # read_holding_registers) gets a fresh allowance each poll instead of
+            # accumulating across cycles or never resetting.
+            hub.begin_poll()
+
             if not hub.ensure_connected():
                 _LOGGER.warning(
                     "Shared Modbus connection could not connect to %s:%s",

--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -411,6 +411,13 @@ class SharedModbusConnection:
         self._lock = threading.Lock()
         self._refcount = 0
         self._connected = False
+        # Per-poll budget for transport-error recoveries (Issue #364). A block-level
+        # reset+retry (see read_input_registers/read_holding_registers) is cheap for the
+        # one-off silent connection loss it's meant to catch, but on a gateway that is
+        # genuinely down every block would trip it, turning one poll into a chain of full
+        # TCP reconnects. begin_poll() resets the budget once per poll cycle.
+        self._recoveries_this_poll = 0
+        self._max_recoveries_per_poll = 2
 
     # ------------------------------------------------------------------
     # Reference counting
@@ -418,6 +425,17 @@ class SharedModbusConnection:
 
     def acquire_ref(self) -> None:
         self._refcount += 1
+
+    def begin_poll(self) -> None:
+        """Reset the per-poll recovery budget. Call once per poll, before any reads."""
+        self._recoveries_this_poll = 0
+
+    def _begin_recovery(self) -> bool:
+        """True if a reset+retry is still within this poll's recovery budget."""
+        if self._recoveries_this_poll >= self._max_recoveries_per_poll:
+            return False
+        self._recoveries_this_poll += 1
+        return True
 
     def release_ref(self) -> None:
         self._refcount -= 1
@@ -512,43 +530,77 @@ class SharedModbusConnection:
     def read_input_registers(self, start: int, count: int, slave_id: int) -> Optional[list]:
         if self._client is None:
             return None
-        try:
+        # Issue #364: a block read can fail two structurally different ways.
+        #
+        # - Transport failure (raised exception: socket dropped, frame corruption). The
+        #   connection is suspect and pymodbus's sync client won't notice on its own
+        #   (see reset()'s docstring) — reset and retry once, budget permitting.
+        # - Protocol refusal (isError(), e.g. Illegal Function/Address). The device
+        #   answered and declined. The socket is healthy; several profiles legitimately
+        #   probe ranges their hardware rejects on every poll (#360, #361), so resetting
+        #   here would be a permanent tax rather than a recovery.
+        for attempt in (0, 1):
             try:
-                resp = self._client.read_input_registers(address=start, count=count, device_id=slave_id)
-            except TypeError:
                 try:
-                    resp = self._client.read_input_registers(address=start, count=count, slave=slave_id)
+                    resp = self._client.read_input_registers(address=start, count=count, device_id=slave_id)
                 except TypeError:
                     try:
-                        resp = self._client.read_input_registers(address=start, count=count, unit=slave_id)
+                        resp = self._client.read_input_registers(address=start, count=count, slave=slave_id)
                     except TypeError:
-                        resp = self._client.read_input_registers(start, count)
+                        try:
+                            resp = self._client.read_input_registers(address=start, count=count, unit=slave_id)
+                        except TypeError:
+                            resp = self._client.read_input_registers(start, count)
+            except Exception as exc:
+                if attempt == 0 and self._begin_recovery():
+                    logger.debug(
+                        "[SharedConn %s:%s] read_input_registers(%d, %d) transport error "
+                        "(%s) — resetting and retrying once",
+                        self.host, self.port, start, count, exc,
+                    )
+                    self.reset("transport error during block read")
+                    if self.ensure_connected():
+                        continue
+                logger.debug("[SharedConn %s:%s] read_input_registers(%d, %d, slave=%d) error: %s",
+                             self.host, self.port, start, count, slave_id, exc)
+                return None
+
             if hasattr(resp, 'isError') and callable(resp.isError) and resp.isError():
                 return None
             return resp.registers if hasattr(resp, 'registers') else None
-        except Exception as exc:
-            logger.debug("[SharedConn %s:%s] read_input_registers(%d, %d, slave=%d) error: %s",
-                         self.host, self.port, start, count, slave_id, exc)
-            return None
+        return None
 
     def read_holding_registers(self, start: int, count: int, slave_id: int) -> Optional[list]:
         if self._client is None:
             return None
-        try:
+        # Same transport-vs-protocol distinction as read_input_registers() above.
+        for attempt in (0, 1):
             try:
-                resp = self._client.read_holding_registers(address=start, count=count, slave=slave_id)
-            except TypeError:
                 try:
-                    resp = self._client.read_holding_registers(address=start, count=count, unit=slave_id)
+                    resp = self._client.read_holding_registers(address=start, count=count, slave=slave_id)
                 except TypeError:
-                    resp = self._client.read_holding_registers(address=start, count=count)
+                    try:
+                        resp = self._client.read_holding_registers(address=start, count=count, unit=slave_id)
+                    except TypeError:
+                        resp = self._client.read_holding_registers(address=start, count=count)
+            except Exception as exc:
+                if attempt == 0 and self._begin_recovery():
+                    logger.debug(
+                        "[SharedConn %s:%s] read_holding_registers(%d, %d) transport error "
+                        "(%s) — resetting and retrying once",
+                        self.host, self.port, start, count, exc,
+                    )
+                    self.reset("transport error during block read")
+                    if self.ensure_connected():
+                        continue
+                logger.debug("[SharedConn %s:%s] read_holding_registers(%d, %d, slave=%d) error: %s",
+                             self.host, self.port, start, count, slave_id, exc)
+                return None
+
             if hasattr(resp, 'isError') and callable(resp.isError) and resp.isError():
                 return None
             return resp.registers if hasattr(resp, 'registers') else None
-        except Exception as exc:
-            logger.debug("[SharedConn %s:%s] read_holding_registers(%d, %d, slave=%d) error: %s",
-                         self.host, self.port, start, count, slave_id, exc)
-            return None
+        return None
 
     def write_register(self, register: int, value: int, slave_id: int) -> bool:
         if self._client is None:


### PR DESCRIPTION
Fixes the gap described in #364.

## What changed

`SharedModbusConnection.read_input_registers()` / `read_holding_registers()` now distinguish two structurally different failure modes, per your comment on #364:

- **Transport failure** (raised exception — socket dropped, frame corruption): the connection is suspect and pymodbus's sync client won't notice on its own. Reset and retry once, budget permitting.
- **Protocol refusal** (`isError()`, e.g. Illegal Function/Address): the device answered and declined. The socket is healthy — resetting here would be a permanent tax on profiles that legitimately probe ranges their hardware rejects every poll (#360, #361), not a recovery.

A per-poll recovery budget (`_max_recoveries_per_poll = 2`) caps how many resets a single poll can trigger. `SharedModbusConnection.begin_poll()` resets the counter once per poll, called from `_fetch_data_shared()` right after the hub lock is acquired, before any reads — so a genuinely dead gateway can't turn one poll into a chain of full TCP reconnects (this is the mechanism you flagged as a possible route into the `FAILED_UNLOAD` state from #361).

## Why (recap from #364)

Since v1.1.8, a failed base-range block on a hybrid profile with 3000+/31000+ ranges no longer makes `read_all_data()` return `None` — it returns partial data instead. Correct for permanently dead ranges, but it also means the poll-level reset+retry from #354/v1.0.14 never fires for a *transiently* failed block: that fix only triggers when the whole poll comes back empty, and a partially-successful poll looks like a normal success to that check.

## Testing

Field-tested for 24h+ on a `MOD_6000_15000TL3_XH` profile, across a version upgrade (v1.1.10 → v1.2.0) and two HA restarts. PV/AC sensors that previously flickered to `0` on the affected base-range block stayed populated throughout, cross-checked against an independent PV reading of the same inverter for agreement.

I left the "not read vs. read as zero" distinction you mentioned out of this PR, since you noted it's a bigger, separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)