### PR TITLE
fix: a batched write holds the bus on direct connections too 

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,6 +8,14 @@
 
 Staged for the next release. **Not yet published** — v1.8.14 is the current stable.
 
+- **A multi-register control can no longer be interrupted halfway on a direct connection.**
+  Controls that write several registers together (the WIT VPP mode select writes six to eight)
+  hold the Modbus bus for the whole sequence, so a poll cannot land in the middle of it. That
+  protection was skipped whenever the connection was not shared between config entries, on the
+  reasoning that such a client owns its socket outright - which stopped being true in v1.8.12,
+  when a whole poll started holding the per-client bus lock. On those setups a poll could still
+  interleave, and a write partway through the sequence could time out with the inverter left
+  half-configured. Shared connections are unaffected. (#331, #398)
 - **Your inverter now tells you if it is on the wrong profile.** Detection ran once during
   setup and was never revisited, so a single timed-out read at that moment could leave an
   inverter on a profile that maps fewer registers than it supports - with nothing to say so.

--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -2924,28 +2924,39 @@ class GrowattModbus:
         2. Keep the block short. The poll waits on this same lock, so a long batch delays
            polling for every entity on the connection.
 
-        A no-op when there is no shared connection: the client owns its socket outright and
-        there is nothing to contend with.
-        """
-        if self._shared_conn is None:
-            yield
-            return
+        It is NOT a no-op without a shared connection. That was the original shape, on the
+        reasoning that a direct client owns its socket outright and has nothing to contend
+        with — true when it was written, false since #398 gave the direct path a
+        `_local_bus_lock` and made a whole poll hold it. With the no-op, each write inside
+        the batch took and released that lock on its own, so a poll could land between two
+        registers of the sequence, and a mid-sequence acquisition could time out with
+        authority already granted and no setpoint written — exactly the half-applied
+        command this method exists to prevent, reached on the one transport that was
+        supposed to be exempt from it.
 
+        Both locks are RLocks, so holding the local one here and re-entering it per write
+        behaves identically to the shared path.
+        """
         from .const import SHARED_LOCK_TIMEOUT
-        acquired = self._shared_conn._lock.acquire(timeout=SHARED_LOCK_TIMEOUT)
-        if not acquired:
+
+        lock = (
+            self._shared_conn._lock if self._shared_conn is not None
+            else self._local_bus_lock
+        )
+        scope = "shared" if self._shared_conn is not None else "local"
+        if not lock.acquire(timeout=SHARED_LOCK_TIMEOUT):
             raise ModbusWriteError(
-                0, [], f"Shared connection busy (lock timeout on {what})"
+                0, [], f"Modbus bus busy (lock timeout on {what})"
             )
         try:
-            logger.debug("[BATCH] Holding shared bus for %s", what)
+            logger.debug("[BATCH] Holding %s bus for %s", scope, what)
             yield
         finally:
             # Released even if a write inside raised. A leaked lock would stall every
             # subsequent poll on this connection — a worse failure than the one this
             # method exists to prevent.
-            self._shared_conn._lock.release()
-            logger.debug("[BATCH] Released shared bus after %s", what)
+            lock.release()
+            logger.debug("[BATCH] Released %s bus after %s", scope, what)
 
     def write_register(self, register: int, value: int) -> bool:
         """Write, holding the bus for the transaction (#398)."""

--- a/tests/test_write_batching.py
+++ b/tests/test_write_batching.py
@@ -185,9 +185,8 @@ def test_the_bus_is_released_when_a_write_inside_the_batch_raises():
     assert freed == [True], "the bus was not released after the batch raised"
 
 
-def test_batch_is_a_no_op_without_a_shared_connection():
-    """Direct connections own their socket outright — there is nothing to contend with,
-    and the batch must not require a hub to exist."""
+def test_the_batch_does_not_require_a_hub_to_exist():
+    """A direct client must still be able to run a batch."""
     client = GrowattModbus(connection_type="tcp", host="10.0.0.1", port=502, slave_id=1)
     client._shared_conn = None
 
@@ -195,6 +194,75 @@ def test_batch_is_a_no_op_without_a_shared_connection():
     with client.write_batch("no hub"):
         entered = True
     assert entered
+
+
+def test_the_batch_holds_the_local_bus_when_there_is_no_hub():
+    """It used to yield immediately without taking any lock, on the reasoning that a
+    direct client owns its socket outright. That stopped being true when #398 gave the
+    direct path `_local_bus_lock` and made `_fetch_data` hold it for a WHOLE poll: with
+    the no-op, each write inside the batch took and released that lock on its own, so a
+    poll could land between two registers of the sequence and a mid-sequence acquisition
+    could time out — the half-applied command this method exists to prevent, on the one
+    transport that was supposed to be exempt from it.
+    """
+    client = GrowattModbus(connection_type="tcp", host="10.0.0.1", port=502, slave_id=1)
+    client._shared_conn = None
+
+    poll_got_in = []
+    inside = threading.Event()
+    finish = threading.Event()
+
+    def _poll():
+        inside.wait(timeout=5)
+        # Non-blocking: the question is whether the bus is free WHILE the batch is open.
+        got = client._local_bus_lock.acquire(blocking=False)
+        poll_got_in.append(got)
+        if got:
+            client._local_bus_lock.release()
+        finish.set()
+
+    t = threading.Thread(target=_poll, daemon=True)
+    t.start()
+    with client.write_batch("direct sequence"):
+        inside.set()
+        finish.wait(timeout=5)
+    t.join(timeout=5)
+
+    assert poll_got_in == [False], "a poll could interleave between two writes of a batch"
+    # ...and released afterwards, or the next poll would stall forever.
+    assert client._local_bus_lock.acquire(blocking=False)
+    client._local_bus_lock.release()
+
+
+def test_a_busy_local_bus_fails_the_batch_before_any_write_lands():
+    """Same guarantee as the shared path: "busy" must mean "nothing was applied"."""
+    client = GrowattModbus(connection_type="tcp", host="10.0.0.1", port=502, slave_id=1)
+    client._shared_conn = None
+
+    held = threading.Event()
+    release = threading.Event()
+
+    def _hold():
+        client._local_bus_lock.acquire()
+        held.set()
+        release.wait(timeout=10)
+        client._local_bus_lock.release()
+
+    t = threading.Thread(target=_hold, daemon=True)
+    t.start()
+    held.wait(timeout=5)
+
+    import growatt_under_test.const as _const
+    original = _const.SHARED_LOCK_TIMEOUT
+    _const.SHARED_LOCK_TIMEOUT = 1
+    try:
+        with pytest.raises(ModbusWriteError):
+            with client.write_batch("direct sequence"):
+                raise AssertionError("the batch body must not run on a busy bus")
+    finally:
+        _const.SHARED_LOCK_TIMEOUT = original
+        release.set()
+        t.join(timeout=5)
 
 
 def test_a_busy_bus_fails_the_batch_before_any_write_lands():


### PR DESCRIPTION
(#331, #398)

write_batch() exists so a control that writes several registers - the WIT VPP mode select writes six to eight - either lands complete or fails without having started. It yielded immediately when there was no shared connection, on the reasoning stated in its own docstring: "the client owns its socket outright and there is nothing to contend with".

That was true when it was written and stopped being true in v1.8.12. #398 gave the direct path a `_local_bus_lock` and made a whole poll hold it, precisely so a write could not land between two blocks of a poll. The reverse is equally true and was not covered: with write_batch a no-op, each write inside the sequence took and released that lock on its own, so a poll could take the bus between two registers of the sequence, and the acquisition partway through could time out after SHARED_LOCK_TIMEOUT with authority already granted and no setpoint written.

So the half-applied command #331 is about was still reachable - on the one transport that was supposed to be exempt from it, and only there, which is the kind of gap that survives because the shared path is the one everybody looks at.

Both locks are RLocks, so holding the local one for the batch and re-entering it per write behaves exactly as the shared path already does. Shared connections are unchanged; so is the failure mode when the bus cannot be had, which still raises before any write is issued.

Two tests, both confirmed red without the change: one asserts the bus is genuinely held for the duration of a direct batch, the other that a busy local bus fails the batch before the body runs. The test that asserted the old no-op is replaced by one that keeps its real purpose - a batch must not require a hub to exist.