### PR TITLE
fix: one dropped frame no longer blanks a VPP control block 

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,6 +8,19 @@
 
 Staged for the next release. **Not yet published** — v1.8.14 is the current stable.
 
+- **A single dropped Modbus frame no longer blanks the VPP controls.** The optional VPP
+  register blocks (control authority, export limit, remote power control) are skipped for
+  a while after a failed read, so firmware that does not implement them is not asked every
+  poll. One failure was enough to trigger that, and a timeout on a healthy inverter looks
+  exactly like a register that does not exist - so a control could stop reflecting the
+  inverter for five minutes at a time, repeatedly, with nothing said about it. A block is
+  now skipped only after three failures in a row, the skip is dropped when the connection
+  is re-established (a dead socket says nothing about a register), and a block that was
+  genuinely not answered stays skipped so the poll does not pay a timeout for it again.
+  Entities backed by a block that was not read now report **unavailable** instead of
+  publishing the default they were built with, which reads as a real "Disabled" or 0.
+  Follow-up to #370.
+
 - **Your inverter now tells you if it is on the wrong profile.** Detection ran once during
   setup and was never revisited, so a single timed-out read at that moment could leave an
   inverter on a profile that maps fewer registers than it supports - with nothing to say so.

--- a/custom_components/growatt_modbus/const.py
+++ b/custom_components/growatt_modbus/const.py
@@ -907,6 +907,25 @@ DAILY_TOTAL_ATTRS = [
 ]
 
 
+# Optional VPP holding blocks (30100, 30200-30201, 30407-30410) are read best-effort: a
+# Modbus error, or the backoff window that follows repeated errors, makes a whole block
+# miss a poll. GrowattData is rebuilt per poll, so a missed block leaves the dataclass
+# defaults, which look exactly like a real "Disabled"/0 reading. Control entities backed
+# by one of these blocks must therefore report unavailable when its flag is False rather
+# than publishing the default - the control-side counterpart of withholding a sensor
+# reading that was not read.
+#
+# control name -> GrowattData flag that is set only when the block actually responded
+VPP_CONTROL_AVAILABILITY_FLAG = {
+    'control_authority': 'vpp_control_authority_available',               # 30100
+    'vpp_export_limit_enable': 'vpp_export_limit_available',              # 30200
+    'vpp_export_limit_power_rate': 'vpp_export_limit_available',          # 30201
+    'remote_power_control_enable': 'vpp_remote_power_available',          # 30407
+    'remote_power_control_charging_time': 'vpp_remote_power_available',   # 30408
+    'remote_charge_and_discharge_power': 'vpp_remote_power_available',    # 30409
+}
+
+
 # ============================================================================
 # DEVICE STRUCTURE - Multi-Device Organization
 # ============================================================================

--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -60,6 +60,35 @@ except ImportError:
 # Configure logging
 logger = logging.getLogger(__name__)
 
+# --- Optional-register backoff --------------------------------------------------------
+# The optional VPP holding blocks (30100, 30200-30201, 30407-30410) are skipped for a
+# while after they fail, so firmware that genuinely does not implement them is not asked
+# every poll. #370 made that skip time-limited; these two constants make it also require
+# more than one failure, because a single Modbus timeout on a healthy inverter is a
+# routine transient event and not evidence about the register.
+#
+# The window is spelled out rather than derived from _OPTIONAL_RANGE_RETRY_SECONDS
+# because tests/test_vpp_holding_retry.py asserts the two numbers are literally the same.
+_VPP_HOLDING_RETRY_S = 300
+_VPP_HOLDING_FAIL_THRESHOLD = 3
+
+# Why an optional read came back empty. The two cases need opposite treatment when the
+# connection is re-established:
+#
+#   ERROR_KIND_LINK        the transport raised (broken pipe, connection reset, no client
+#                          at all). Says nothing about the register, and a fresh socket
+#                          makes it worth retrying at once.
+#   ERROR_KIND_NO_RESPONSE the request went out on a working socket and came back as an
+#                          error response, a short frame or nothing. That is evidence
+#                          about the register itself, and re-arming it on every reconnect
+#                          costs a full timeout per poll, so it must survive one.
+#
+# This is the limitation #370 recorded honestly and left open: "a transport error and a
+# genuine illegal data address are still conflated here, because read_holding_registers
+# returns None for both".
+ERROR_KIND_LINK = "link"
+ERROR_KIND_NO_RESPONSE = "no-response"
+
 
 # =============================================================================
 # Custom Exceptions for better error reporting
@@ -327,6 +356,7 @@ class GrowattData:
     vpp_export_limit_power_rate: int = 0      # -100 to +100% (positive=export, 0=zero export)
     vpp_export_limit_available: bool = False  # True if inverter actually responded to registers 30200-30201
     vpp_control_authority_available: bool = False  # True if inverter actually responded to register 30100
+    vpp_remote_power_available: bool = False  # True if inverter actually responded to registers 30407-30410
 
     # MOD TL3-XH TOU periods (FC04 holding registers 3038-3045, raw packed values)
     # Start reg: bit15=enable, bit13-14=priority(0=Load,1=Batt,2=Grid), bit8-12=hour, bit0-7=min
@@ -483,6 +513,13 @@ class SharedModbusConnection:
         self._lock = threading.RLock()
         self._refcount = 0
         self._connected = False
+        # Incremented every time a *new* socket is established. Consumers use it to drop
+        # state derived from the previous session — see
+        # GrowattModbus._sync_optional_blacklists_with_connection().
+        self.connection_generation = 0
+        # Why the most recent read on this hub failed: ERROR_KIND_LINK /
+        # ERROR_KIND_NO_RESPONSE, or None after a successful read.
+        self.last_error_kind: Optional[str] = None
         # Per-poll budget for transport-error recoveries (Issue #364). A block-level
         # reset+retry (see read_input_registers/read_holding_registers) is cheap for the
         # one-off silent connection loss it's meant to catch, but on a gateway that is
@@ -594,6 +631,7 @@ class SharedModbusConnection:
         result = self._client.connect()
         if result:
             self._connected = True
+            self.connection_generation += 1
             self._flush_receive_buffer()
         elif self.is_serial:
             # pyserial logs "[Errno 11] Could not exclusively lock port ..." and pymodbus
@@ -742,6 +780,8 @@ class SharedModbusConnection:
 
     def read_input_registers(self, start: int, count: int, slave_id: int) -> Optional[list]:
         if self._client is None:
+            # No socket at all is a link problem, not evidence about the register.
+            self.last_error_kind = ERROR_KIND_LINK
             return None
         # Issue #364: a block read can fail two structurally different ways.
         #
@@ -765,6 +805,7 @@ class SharedModbusConnection:
                         except TypeError:
                             resp = self._client.read_input_registers(start, count)
             except Exception as exc:
+                self.last_error_kind = ERROR_KIND_LINK
                 if attempt == 0 and self._begin_recovery():
                     logger.debug(
                         "[SharedConn %s] read_input_registers(%d, %d) transport error "
@@ -778,11 +819,17 @@ class SharedModbusConnection:
                              self.connection_id, start, count, slave_id, exc)
                 return None
 
-            return self._validate_registers(resp, start, count)
+            registers = self._validate_registers(resp, start, count)
+            # The request went out on a working socket, so an error response or a short
+            # frame is evidence about the register itself and must survive a reconnect.
+            self.last_error_kind = None if registers is not None else ERROR_KIND_NO_RESPONSE
+            return registers
         return None
 
     def read_holding_registers(self, start: int, count: int, slave_id: int) -> Optional[list]:
         if self._client is None:
+            # No socket at all is a link problem, not evidence about the register.
+            self.last_error_kind = ERROR_KIND_LINK
             return None
         # Same transport-vs-protocol distinction as read_input_registers() above.
         for attempt in (0, 1):
@@ -795,6 +842,7 @@ class SharedModbusConnection:
                     except TypeError:
                         resp = self._client.read_holding_registers(address=start, count=count)
             except Exception as exc:
+                self.last_error_kind = ERROR_KIND_LINK
                 if attempt == 0 and self._begin_recovery():
                     logger.debug(
                         "[SharedConn %s] read_holding_registers(%d, %d) transport error "
@@ -808,7 +856,11 @@ class SharedModbusConnection:
                              self.connection_id, start, count, slave_id, exc)
                 return None
 
-            return self._validate_registers(resp, start, count)
+            registers = self._validate_registers(resp, start, count)
+            # The request went out on a working socket, so an error response or a short
+            # frame is evidence about the register itself and must survive a reconnect.
+            self.last_error_kind = None if registers is not None else ERROR_KIND_NO_RESPONSE
+            return registers
         return None
 
     # Writes reset and retry once on a transport error, exactly as the reads above do
@@ -1009,11 +1061,28 @@ class GrowattModbus:
         # Entries expire after _OPTIONAL_RANGE_RETRY_SECONDS and are retried.
         self._failed_optional_ranges: dict = {}
 
-        # Anchor address -> timestamp of its last failure, for the optional VPP holding
-        # blocks (30100, 30200, 30407). Skipped while inside the retry window, then tried
-        # again — see the read path for why this is a dict rather than the set it was
-        # until #370, and what a permanent skip cost the user who found it.
+        # Anchor address -> (last_fail_time, consecutive_fail_count) for the optional VPP
+        # holding blocks (30100, 30200, 30407). Skipped only after
+        # _VPP_HOLDING_FAIL_THRESHOLD consecutive failures, and even then only until the
+        # retry window expires — see the read path for what a permanent skip cost the user
+        # who found it in #370, and why one failure is not enough to act on.
         self._failed_optional_holding_addrs: dict = {}
+
+        # Generation of the shared connection the two records above were built against.
+        # A reconnect invalidates the failures that were caused by the connection itself.
+        self._optional_blacklist_conn_generation: int = (
+            getattr(shared_conn, 'connection_generation', 0) if shared_conn is not None else 0
+        )
+
+        # Why each backed-off optional read last failed, so a reconnect can re-arm the ones
+        # that were only ever a symptom of a dead socket while leaving the ones the inverter
+        # genuinely does not answer backed off. Keys are ('range', range_key) and
+        # ('holding', anchor); values are ERROR_KIND_LINK / ERROR_KIND_NO_RESPONSE.
+        self._optional_failure_kinds: dict = {}
+
+        # Classification of the most recent read, set by the read methods below and
+        # consumed by _note_optional_failure_kind().
+        self._last_read_error_kind: Optional[str] = None
 
         # Last successfully read battery SOC — used to hold value if VPP range is
         # temporarily unavailable rather than reporting a misleading 0%.
@@ -1232,6 +1301,106 @@ class GrowattModbus:
                     logger.error(f"[{self.register_map['name']}@{self.connection_id}] CRITICAL: File descriptor leak detected!")
                     raise
     
+    # ------------------------------------------------------------------
+    # Optional-register backoff bookkeeping
+    # ------------------------------------------------------------------
+
+    def _optional_holding_blocked(self, anchor: int) -> bool:
+        """Whether an optional holding block should be skipped on this poll."""
+        entry = self._failed_optional_holding_addrs.get(anchor)
+        if not entry:
+            return False
+        last_fail, fail_count = entry
+        if fail_count < _VPP_HOLDING_FAIL_THRESHOLD:
+            # Not enough consecutive failures yet. A transient error must not take a
+            # control block out of service, which is what a threshold of one did.
+            return False
+        if time.time() - last_fail >= _VPP_HOLDING_RETRY_S:
+            # Retry window expired. The entry is deliberately kept so the count keeps
+            # growing (and the log line stays suppressed) if the re-read fails again; a
+            # successful read clears it.
+            return False
+        return True
+
+    def _record_optional_holding_failure(self, anchor: int, label: str) -> None:
+        """Count a failed optional holding-block read and log the transition once."""
+        previous = self._failed_optional_holding_addrs.get(anchor)
+        fail_count = (previous[1] + 1) if previous else 1
+        self._failed_optional_holding_addrs[anchor] = (time.time(), fail_count)
+        self._note_optional_failure_kind(('holding', anchor))
+        if fail_count == _VPP_HOLDING_FAIL_THRESHOLD:
+            logger.debug(
+                "[VPP] %s failed %d consecutive polls — skipping for %ds, then retrying. "
+                "If this repeats indefinitely the firmware likely does not implement it.",
+                label, fail_count, _VPP_HOLDING_RETRY_S,
+            )
+        else:
+            logger.debug("[VPP] %s read failed (attempt %d)", label, fail_count)
+
+    def _note_optional_failure_kind(self, key) -> None:
+        """Remember why an optional read last failed (see clear_optional_blacklists)."""
+        kind = self._last_read_error_kind
+        if kind is None and self._shared_conn is not None:
+            kind = getattr(self._shared_conn, 'last_error_kind', None)
+        self._optional_failure_kinds[key] = kind or ERROR_KIND_LINK
+
+    def clear_optional_blacklists(self, reason: str = "", link_failures_only: bool = True) -> None:
+        """Re-arm optional reads that were only backed off because the link was down.
+
+        A read that failed because the transport raised (ERROR_KIND_LINK) says nothing
+        about the register, so a fresh socket must retry it. A read that failed with
+        ERROR_KIND_NO_RESPONSE went out on a working socket and was not answered;
+        re-arming that on every reconnect is how a poll ends up paying a full timeout per
+        unanswered register again and again, so those entries survive and keep counting
+        down their retry window.
+
+        ``link_failures_only=False`` clears everything.
+        """
+        def _keep(key) -> bool:
+            if not link_failures_only:
+                return False
+            # An unknown kind is treated as a link failure: that is the conservative
+            # direction, since a transient error must never take a control block out of
+            # service for the life of the process.
+            return self._optional_failure_kinds.get(key) == ERROR_KIND_NO_RESPONSE
+
+        dropped_ranges = [k for k in self._failed_optional_ranges if not _keep(('range', k))]
+        dropped_holdings = [
+            a for a in self._failed_optional_holding_addrs if not _keep(('holding', a))
+        ]
+        if not dropped_ranges and not dropped_holdings:
+            return
+        logger.info(
+            "[%s@%s] Clearing optional-register backoff (%d range(s), %d holding block(s))%s",
+            self.register_map['name'], self.connection_id,
+            len(dropped_ranges), len(dropped_holdings),
+            f": {reason}" if reason else "",
+        )
+        for key in dropped_ranges:
+            self._failed_optional_ranges.pop(key, None)
+            self._optional_failure_kinds.pop(('range', key), None)
+        for anchor in dropped_holdings:
+            self._failed_optional_holding_addrs.pop(anchor, None)
+            self._optional_failure_kinds.pop(('holding', anchor), None)
+
+    def _sync_optional_blacklists_with_connection(self) -> None:
+        """Drop backoff state built against a connection that has since been replaced.
+
+        The shared hub owns the socket and can reconnect underneath us (#354, #364). Its
+        connection_generation changes on every fresh connect, which is the signal that the
+        previous session's failures no longer say anything.
+
+        Only the shared path is handled here. The non-shared path reconnects on *every*
+        poll by design, so clearing there would disable the backoff entirely; that path
+        relies on the failure threshold and the retry window instead.
+        """
+        if self._shared_conn is None:
+            return
+        generation = getattr(self._shared_conn, 'connection_generation', 0)
+        if generation != self._optional_blacklist_conn_generation:
+            self._optional_blacklist_conn_generation = generation
+            self.clear_optional_blacklists("connection re-established")
+
     def _track_read_success(self):
         """Track successful read and restore fast polling if we had backed off"""
         if self._consecutive_read_failures > 0:
@@ -1286,9 +1455,14 @@ class GrowattModbus:
             log_errors: If False, downgrade Modbus errors to DEBUG (for optional ranges expected to fail on some models)
         """
         self._enforce_read_interval()
+        self._last_read_error_kind = None
 
         if self._shared_conn is not None:
             registers = self._shared_conn.read_input_registers(start_address, count, self.slave_id)
+            # The hub classifies *why* the read came back empty; the optional-register
+            # backoff needs that to tell a dead socket from a register the inverter does
+            # not answer (see _note_optional_failure_kind).
+            self._last_read_error_kind = self._shared_conn.last_error_kind
             # This used to return directly, bypassing the failure counters below — so
             # _consecutive_read_failures never moved for any TCP entry and the adaptive
             # backoff could not engage for them at all (#367).
@@ -1335,12 +1509,14 @@ class GrowattModbus:
                 if response.isError():
                     _log = logger.warning if log_errors else logger.debug
                     _log(f"Modbus error reading input registers {start_address}-{start_address+count-1}: {response}")
+                    self._last_read_error_kind = ERROR_KIND_NO_RESPONSE
                     self._track_read_failure()
                     return None
             elif hasattr(response, 'is_error') and callable(response.is_error):
                 if response.is_error():
                     _log = logger.warning if log_errors else logger.debug
                     _log(f"Modbus error reading input registers {start_address}-{start_address+count-1}: {response}")
+                    self._last_read_error_kind = ERROR_KIND_NO_RESPONSE
                     self._track_read_failure()
                     return None
 
@@ -1352,6 +1528,7 @@ class GrowattModbus:
                         "(adapter online but inverter not responding — likely night-time sleep)",
                         start_address, start_address + count - 1
                     )
+                    self._last_read_error_kind = ERROR_KIND_NO_RESPONSE
                     self._track_read_failure()
                     return None
                 if len(registers) < count:
@@ -1359,6 +1536,7 @@ class GrowattModbus:
                         "Inverter returned only %d of %d requested registers at %d — treating as failure",
                         len(registers), count, start_address
                     )
+                    self._last_read_error_kind = ERROR_KIND_NO_RESPONSE
                     self._track_read_failure()
                     return None
                 logger.debug("Successfully read %d registers from %d", len(registers), start_address)
@@ -1366,11 +1544,13 @@ class GrowattModbus:
                 return registers
 
             logger.warning(f"Unknown response type: {type(response)}, response: {response}")
+            self._last_read_error_kind = ERROR_KIND_NO_RESPONSE
             self._track_read_failure()
             return None
 
         except Exception as e:
             logger.debug(f"Exception reading input registers: {e}")
+            self._last_read_error_kind = ERROR_KIND_LINK
             self._track_read_failure()
             return None
     
@@ -1382,9 +1562,11 @@ class GrowattModbus:
     def _read_holding_registers_locked(self, start_address: int, count: int) -> Optional[list]:
         """Read holding registers with error handling and slave_id compatibility fallback."""
         self._enforce_read_interval()
+        self._last_read_error_kind = None
 
         if self._shared_conn is not None:
             registers = self._shared_conn.read_holding_registers(start_address, count, self.slave_id)
+            self._last_read_error_kind = self._shared_conn.last_error_kind
             # Same bypass as read_input_registers above (#367).
             if registers is None:
                 self._track_read_failure()
@@ -1402,16 +1584,19 @@ class GrowattModbus:
                     response = self.client.read_holding_registers(address=start_address, count=count)
             if hasattr(response, "isError") and callable(response.isError) and response.isError():
                 logger.debug("Modbus error reading holding registers %d-%d: %r", start_address, start_address + count - 1, response)
+                self._last_read_error_kind = ERROR_KIND_NO_RESPONSE
                 self._track_read_failure()
                 return None
             if hasattr(response, "registers"):
                 self._track_read_success()
                 return response.registers
             logger.debug("Unexpected response type from read_holding_registers(%d, %d): %r", start_address, count, response)
+            self._last_read_error_kind = ERROR_KIND_NO_RESPONSE
             self._track_read_failure()
             return None
         except Exception as e:
             logger.debug("Exception reading holding registers %d-%d: %s", start_address, start_address + count - 1, e)
+            self._last_read_error_kind = ERROR_KIND_LINK
             self._track_read_failure()
             return None
 
@@ -1942,6 +2127,10 @@ class GrowattModbus:
 
     def read_all_data(self) -> Optional[GrowattData]:
         """Read all relevant data from inverter"""
+        # A reconnect invalidates the optional-register backoff built up on the previous
+        # socket (see _sync_optional_blacklists_with_connection).
+        self._sync_optional_blacklists_with_connection()
+
         data = GrowattData()
         
         # Determine register range based on map
@@ -2221,6 +2410,7 @@ class GrowattModbus:
                     _prev = self._failed_optional_ranges.get(_3000_key)
                     _count = (_prev[1] + 1) if _prev else 1
                     self._failed_optional_ranges[_3000_key] = (time.time(), _count)
+                    self._note_optional_failure_kind(('range', _3000_key))
                     if _count == 1:
                         logger.warning(
                             f"Failed to read 3000 register block (extended data may be unavailable). "
@@ -2230,6 +2420,7 @@ class GrowattModbus:
                         logger.debug(f"3000 register block still failing (attempt {_count})")
                 elif _3000_any_ok:
                     self._failed_optional_ranges.pop(_3000_key, None)
+                    self._optional_failure_kinds.pop(('range', _3000_key), None)
 
         # Read 8000 range if needed - WIT/WIS battery/storage data
         if has_8000_range:
@@ -2330,6 +2521,7 @@ class GrowattModbus:
                         _prev = self._failed_optional_ranges.get(range_key)
                         _fail_count = (_prev[1] + 1) if _prev else 1
                         self._failed_optional_ranges[range_key] = (time.time(), _fail_count)
+                        self._note_optional_failure_kind(('range', range_key))
                         if _fail_count == 1:
                             logger.warning(
                                 f"Optional VPP range ({min_addr_block}-{max_addr_block}) failed — "
@@ -2346,6 +2538,7 @@ class GrowattModbus:
                     # Range succeeded — clear any previous failure record so the
                     # next failure is treated as fresh (warn again on first failure).
                     self._failed_optional_ranges.pop(range_key, None)
+                    self._optional_failure_kinds.pop(('range', range_key), None)
                     # Populate cache
                     for i, value in enumerate(registers):
                         self._register_cache[min_addr_block + i] = value
@@ -4862,32 +5055,31 @@ class GrowattModbus:
         # with exactly this retry. This set never received the same treatment — the two
         # mechanisms sit a few hundred lines apart and only one of them was corrected.
         #
-        # Worth stating the limitation honestly: a transport error and a genuine
-        # "illegal data address" are still conflated here, because read_holding_registers
-        # returns None for both. Retrying every 5 minutes makes an unsupported register
-        # cost one wasted read per 5 minutes, which is cheap; the previous behaviour made
-        # a supported register cost everything.
-        _VPP_HOLDING_RETRY_S = 300
+        # #370 left one limitation stated openly: "a transport error and a genuine
+        # illegal data address are still conflated here, because read_holding_registers
+        # returns None for both". That is what the helpers below close, and it matters
+        # because the retry window alone still lets ONE dropped frame blank a control
+        # block for five minutes, over and over, on an inverter that answers perfectly.
+        # Three things sit on top of the flat window now:
+        #
+        #   * a block is skipped only after _VPP_HOLDING_FAIL_THRESHOLD *consecutive*
+        #     failures, so a single transient error suppresses nothing at all;
+        #   * the failure is classified (ERROR_KIND_LINK / ERROR_KIND_NO_RESPONSE), so a
+        #     reconnect re-arms the blocks that only failed because the socket was dead
+        #     while leaving genuinely unimplemented registers backed off;
+        #   * each block sets an *_available flag on success, and the control entities
+        #     report unavailable rather than publishing the GrowattData default, which is
+        #     indistinguishable from a real "Disabled"/0 reading.
+        #
+        # The two names below are #370's and are kept: this is one mechanism, not two.
 
         def _vpp_block_skipped(anchor: int) -> bool:
             """True while this anchor is inside its retry window."""
-            prev = self._failed_optional_holding_addrs.get(anchor)
-            if prev is None:
-                return False
-            if time.time() - prev >= _VPP_HOLDING_RETRY_S:
-                logger.debug("[VPP] Retrying previously failed holding block at %d", anchor)
-                return False
-            return True
+            return self._optional_holding_blocked(anchor)
 
         def _vpp_block_failed(anchor: int, what: str) -> None:
-            first = anchor not in self._failed_optional_holding_addrs
-            self._failed_optional_holding_addrs[anchor] = time.time()
-            if first:
-                logger.debug(
-                    "[VPP] %s did not respond — skipping for %ds, then retrying. "
-                    "If this repeats indefinitely the firmware likely does not "
-                    "implement it.", what, _VPP_HOLDING_RETRY_S,
-                )
+            """Record a failed optional block read."""
+            self._record_optional_holding_failure(anchor, what)
 
         # Control Authority (30100)
         if 30100 in holding_map and not _vpp_block_skipped(30100):
@@ -4896,11 +5088,18 @@ class GrowattModbus:
                 if vpp_ctrl_regs is not None and len(vpp_ctrl_regs) >= 1:
                     data.control_authority = int(vpp_ctrl_regs[0])
                     data.vpp_control_authority_available = True
+                    # A good read re-arms the block at once: the failure record and the
+                    # remembered error kind go together, or clear_optional_blacklists()
+                    # would keep reasoning about a failure that no longer exists.
                     self._failed_optional_holding_addrs.pop(30100, None)
+                    self._optional_failure_kinds.pop(('holding', 30100), None)
                     logger.debug("[VPP] control_authority=%s", data.control_authority)
                 else:
                     _vpp_block_failed(30100, "Register 30100 (control authority)")
             except Exception as e:
+                # An exception is a failure like any other. Not counting it here is how a
+                # block could fail every poll forever without the backoff ever engaging.
+                _vpp_block_failed(30100, "Register 30100 (control authority)")
                 logger.debug(f"Could not read VPP control_authority register 30100: {e}")
 
         # VPP Export Limitation (30200-30201)
@@ -4918,11 +5117,13 @@ class GrowattModbus:
                         data.vpp_export_limit_power_rate = int(raw_val)
                     data.vpp_export_limit_available = True
                     self._failed_optional_holding_addrs.pop(30200, None)
+                    self._optional_failure_kinds.pop(('holding', 30200), None)
                     logger.debug("[VPP] vpp_export_limit_enable=%s, vpp_export_limit_power_rate=%s%%",
                                data.vpp_export_limit_enable, data.vpp_export_limit_power_rate)
                 else:
                     _vpp_block_failed(30200, "Registers 30200-30201 (export limit)")
             except Exception as e:
+                _vpp_block_failed(30200, "Registers 30200-30201 (export limit)")
                 logger.debug(f"Could not read VPP export limitation registers 30200-30201: {e}")
 
         # Remote Power Control (30407-30410)
@@ -4945,10 +5146,17 @@ class GrowattModbus:
                     logger.debug("[VPP] remote_power_control_enable=%s, charging_time=%s min, charge_discharge_power=%s%%, ac_charge_enable=%s",
                                data.remote_power_control_enable, data.remote_power_control_charging_time,
                                data.remote_charge_and_discharge_power, data.vpp_ac_charge_enable)
+                    # The block responded. Without this flag the controls behind
+                    # 30407-30410 cannot tell "the inverter says Disabled" from "the block
+                    # was not read this poll", and publish the dataclass default as if it
+                    # had been measured.
+                    data.vpp_remote_power_available = True
                     self._failed_optional_holding_addrs.pop(30407, None)
+                    self._optional_failure_kinds.pop(('holding', 30407), None)
                 else:
                     _vpp_block_failed(30407, "Registers 30407-30410 (remote power control)")
             except Exception as e:
+                _vpp_block_failed(30407, "Registers 30407-30410 (remote power control)")
                 logger.debug(f"Could not read VPP remote power control registers 30407-30410: {e}")
 
     def get_status_text(self, status_code: int) -> str:

--- a/custom_components/growatt_modbus/number.py
+++ b/custom_components/growatt_modbus/number.py
@@ -17,6 +17,7 @@ from .const import (
     control_is_blocked,
     get_device_type_for_control,
     is_read_only_register,
+    VPP_CONTROL_AVAILABILITY_FLAG,
 )
 from .coordinator import GrowattModbusCoordinator
 from .entity import GrowattEntity
@@ -247,10 +248,27 @@ class GrowattGenericNumber(GrowattEntity, NumberEntity):
         Declarative as `('field', value)` rather than a callable: a lambda here would be
         hard to test and easy to make decorative, which is a mistake this project has
         already shipped once.
+
+        The second reason is a block that was not read at all this poll. Registers
+        30100 / 30200-30201 / 30407-30410 are optional best-effort reads; when one is
+        missed, GrowattData still carries its dataclass default (0), which would be
+        published as a real "Disabled"/0 setting. VPP_CONTROL_AVAILABILITY_FLAG maps the
+        control to the flag that proves its block responded; controls not backed by such
+        a block have no entry and are unaffected.
+
+        The two conditions are ANDed rather than substituted for one another: they answer
+        different questions ("will the write be accepted?" vs "do we know the current
+        value?").
         """
         if not super().available:
             return False
-        return not control_is_blocked(self._control_config, self.coordinator.data)
+        if control_is_blocked(self._control_config, self.coordinator.data):
+            return False
+        flag = VPP_CONTROL_AVAILABILITY_FLAG.get(self._control_name)
+        if flag is None:
+            return True
+        data = self.coordinator.data
+        return bool(data is not None and getattr(data, flag, False))
 
     def _get_icon(self, control_name: str) -> str:
         """Get icon based on control name."""
@@ -318,6 +336,14 @@ class GrowattGenericNumber(GrowattEntity, NumberEntity):
         """Return the current value."""
         data = self.coordinator.data
         if data is None:
+            return None
+
+        # A block that was not read this poll carries dataclass defaults - report unknown
+        # rather than a fabricated value (see available()). Kept in addition to the
+        # availability gate because Home Assistant keeps the last state of an unavailable
+        # entity, and a 0 written there once would linger as a plausible-looking value.
+        flag = VPP_CONTROL_AVAILABILITY_FLAG.get(self._control_name)
+        if flag is not None and not getattr(data, flag, False):
             return None
 
         raw_value = getattr(data, self._control_name, None)

--- a/custom_components/growatt_modbus/select.py
+++ b/custom_components/growatt_modbus/select.py
@@ -18,6 +18,7 @@ from .const import (
     is_read_only_register,
     DEVICE_TYPE_BATTERY,
     MOD_TOU_PERIODS,
+    VPP_CONTROL_AVAILABILITY_FLAG,
 )
 from .coordinator import GrowattModbusCoordinator
 from .entity import GrowattEntity
@@ -271,10 +272,36 @@ class GrowattGenericSelect(GrowattEntity, SelectEntity):
         return icon_map.get(control_name, 'mdi:tune')
 
     @property
+    def available(self) -> bool:
+        """Unavailable while the backing VPP block was not read this poll.
+
+        Registers 30100 / 30200-30201 / 30407-30410 are optional best-effort reads. When
+        a block is missed, GrowattData carries its dataclass default (0), which would
+        otherwise be published as a real "Disabled"/0 setting. Reporting unavailable is
+        the same choice the sensor platform makes for a reading that was not taken.
+        Controls not backed by such a block have no entry in the map and are unaffected.
+        """
+        if not super().available:
+            return False
+        flag = VPP_CONTROL_AVAILABILITY_FLAG.get(self._control_name)
+        if flag is None:
+            return True
+        data = self.coordinator.data
+        return bool(data is not None and getattr(data, flag, False))
+
+    @property
     def current_option(self) -> str | None:
         """Return the current selected option."""
         data = self.coordinator.data
         if data is None:
+            return None
+
+        # A block that was not read this poll carries dataclass defaults - report unknown
+        # rather than a fabricated value (see available()). Kept in addition to the
+        # availability gate because Home Assistant keeps the last state of an unavailable
+        # entity, and a 0 written there once would linger as a plausible-looking value.
+        flag = VPP_CONTROL_AVAILABILITY_FLAG.get(self._control_name)
+        if flag is not None and not getattr(data, flag, False):
             return None
 
         # Read raw value from coordinator data

--- a/docs/controls/entity-reference.md
+++ b/docs/controls/entity-reference.md
@@ -209,6 +209,14 @@ what your model allows will be rejected by the inverter and the entity will reve
 | Remote Control Duration | Number | 30408 | 0–1440 min | Duration for remote power control override |
 | Remote Charge/Discharge Power | Number | 30409 | -100–+100 % | Power level (negative=discharge, positive=charge) |
 
+**The six VPP controls (30100, 30200-30201, 30407-30409) go unavailable when their
+register block does not answer a poll.** Those blocks are read best-effort, because not
+every firmware implements them, and a block that is missed leaves the integration with no
+reading rather than a stale one. An occasional flick to unavailable is a dropped Modbus
+frame; permanently unavailable means your firmware does not implement the block. In
+neither case is a "Disabled" or 0 shown that the inverter did not report
+([#370](https://github.com/0xAHA/Growatt_ModbusTCP/issues/370)).
+
 **Important notes:**
 - WIT uses a **time-limited override** model. Commands via registers 30407–30409 expire after the configured duration or when HA restarts. The inverter then returns to its TOU schedule default.
 - Register 30476 (`priority_mode`) on WIT shows the base TOU mode. Writability **varies by model** - it was documented as read-only, but has been written successfully for months on a WIT 8000TL3-HU ([#353](https://github.com/0xAHA/Growatt_ModbusTCP/issues/353)). The TOU Default Mode control writes it; if your model rejects the write, use the inverter display or Growatt app instead.

--- a/tests/test_optional_holding_backoff.py
+++ b/tests/test_optional_holding_backoff.py
@@ -1,0 +1,480 @@
+"""One dropped frame must not blank a VPP control block (#370 follow-up).
+
+Registers 30100 (control authority), 30200-30201 (export limit) and 30407-30410 (remote
+power control) are read best-effort inside `_read_device_info`, because some firmware
+variants do not implement them. A failing anchor is recorded so the block is skipped
+rather than asked again every poll.
+
+#370 made that record expire after 300 s, which fixed the permanent case. It left the
+threshold at one: a single failed read still takes the block out of service for five
+minutes, and `read_holding_registers` returns None for a transport error and for a
+genuine "illegal data address" alike, so an inverter that answers perfectly is treated
+exactly like one that does not implement the register.
+
+That is not hypothetical. On a WIT on 2026-09-01T03:46:34Z one transient read failure was
+enough; the registers themselves were verified fine by reading them directly for the next
+30 h, while the entities derived from them sat on the GrowattData defaults - which are
+indistinguishable from a real "Disabled"/0 reading - the whole time.
+
+These tests pin the four properties that make that impossible:
+
+  * a block is skipped only after several CONSECUTIVE failures,
+  * the skip expires and the block is retried,
+  * a reconnect re-arms the blocks that only failed because the socket was dead, and
+    leaves backed off the ones the inverter genuinely did not answer,
+  * a block that was not read publishes nothing: its *_available flag stays False and the
+    control entities report unavailable instead of the default.
+"""
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+
+_gm = importlib.import_module("growatt_under_test.growatt_modbus")
+_const = importlib.import_module("growatt_under_test.const")
+
+GrowattModbus = _gm.GrowattModbus
+GrowattData = _gm.GrowattData
+SharedModbusConnection = _gm.SharedModbusConnection
+
+WIT_MAP = "WIT_4000_15000TL3"
+ANCHORS = (30100, 30200, 30407)
+
+
+class FakeHoldingReads:
+    """Stand-in for `GrowattModbus.read_holding_registers`.
+
+    `fail` holds start addresses that return None (what the real method does for every
+    error, including exceptions). `values` supplies register contents for specific start
+    addresses; anything else reads back as zeros.
+    """
+
+    def __init__(self, fail=(), values=None):
+        self.fail = set(fail)
+        self.values = dict(values or {})
+        self.calls = []
+
+    def __call__(self, start_address, count):
+        self.calls.append((start_address, count))
+        if start_address in self.fail:
+            return None
+        if start_address in self.values:
+            return list(self.values[start_address])
+        return [0] * count
+
+    def starts(self):
+        return [start for start, _ in self.calls]
+
+
+class RaisingHoldingReads(FakeHoldingReads):
+    """Raises instead of returning None, which is the other way a read can fail."""
+
+    def __call__(self, start_address, count):
+        self.calls.append((start_address, count))
+        if start_address in self.fail:
+            raise OSError(104, "Connection reset by peer")
+        return [0] * count
+
+
+class KindedHoldingReads(FakeHoldingReads):
+    """FakeHoldingReads that also reports *why* a read failed, like the real method."""
+
+    def __init__(self, fail=(), values=None, kind=None, client=None):
+        super().__init__(fail=fail, values=values)
+        self.kind = kind
+        self.client = client
+
+    def __call__(self, start_address, count):
+        result = super().__call__(start_address, count)
+        if self.client is not None:
+            self.client._last_read_error_kind = self.kind if result is None else None
+        return result
+
+
+class FakeHub:
+    """Minimal stand-in for SharedModbusConnection (generation counter only)."""
+
+    def __init__(self):
+        self.connection_generation = 0
+        self.last_error_kind = None
+
+    def reconnect(self):
+        self.connection_generation += 1
+
+
+def _client(hub=None):
+    return GrowattModbus(
+        connection_type="tcp", host="10.0.0.1", port=502,
+        register_map=WIT_MAP, shared_conn=hub,
+    )
+
+
+@pytest.fixture
+def wit_client():
+    """A WIT client whose holding reads are fully controlled by the test."""
+    return _client()
+
+
+def _read_device_info(client, reads):
+    """Run _read_device_info with the given fake reads, returning fresh GrowattData."""
+    client.read_holding_registers = reads
+    data = GrowattData()
+    client._read_device_info(data)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Threshold: a transient failure must not blacklist anything
+# ---------------------------------------------------------------------------
+
+
+def test_single_failure_does_not_skip_the_block(wit_client):
+    """One failed read must leave the block eligible on the very next poll."""
+    _read_device_info(wit_client, FakeHoldingReads(fail=set(ANCHORS)))
+
+    for anchor in ANCHORS:
+        assert wit_client._optional_holding_blocked(anchor) is False
+
+    reads = FakeHoldingReads(fail=set(ANCHORS))
+    _read_device_info(wit_client, reads)
+    for anchor in ANCHORS:
+        assert anchor in reads.starts()
+
+
+def test_block_skipped_only_after_threshold_consecutive_failures(wit_client):
+    threshold = _gm._VPP_HOLDING_FAIL_THRESHOLD
+    assert threshold >= 2, "a threshold of 1 is the bug this test guards against"
+
+    for poll in range(1, threshold + 1):
+        reads = FakeHoldingReads(fail={30407})
+        _read_device_info(wit_client, reads)
+        assert 30407 in reads.starts(), f"poll {poll} should still attempt the block"
+
+    assert wit_client._optional_holding_blocked(30407) is True
+
+    reads = FakeHoldingReads(fail={30407})
+    _read_device_info(wit_client, reads)
+    assert 30407 not in reads.starts()
+
+
+def test_an_exception_counts_as_a_failure(wit_client):
+    """read_holding_registers can raise as well as return None. Both used to be handled,
+    but only one of them was counted, so a block failing that way was retried at full
+    price on every poll for the life of the process."""
+    threshold = _gm._VPP_HOLDING_FAIL_THRESHOLD
+    for _ in range(threshold):
+        _read_device_info(wit_client, RaisingHoldingReads(fail={30407}))
+
+    assert wit_client._optional_holding_blocked(30407) is True
+
+
+def test_success_clears_the_failure_count(wit_client):
+    """A good read resets the streak, so the threshold counts *consecutive* failures."""
+    threshold = _gm._VPP_HOLDING_FAIL_THRESHOLD
+
+    for _ in range(threshold - 1):
+        _read_device_info(wit_client, FakeHoldingReads(fail={30407}))
+
+    _read_device_info(wit_client, FakeHoldingReads(values={30407: [1, 20, 65436, 1]}))
+    assert 30407 not in wit_client._failed_optional_holding_addrs
+
+    _read_device_info(wit_client, FakeHoldingReads(fail={30407}))
+    assert wit_client._optional_holding_blocked(30407) is False
+
+
+# ---------------------------------------------------------------------------
+# Expiry (#370, kept)
+# ---------------------------------------------------------------------------
+
+
+def test_blacklist_expires_and_the_block_is_retried(wit_client):
+    threshold = _gm._VPP_HOLDING_FAIL_THRESHOLD
+
+    for _ in range(threshold):
+        _read_device_info(wit_client, FakeHoldingReads(fail={30407}))
+    assert wit_client._optional_holding_blocked(30407) is True
+
+    # Age the entry past the retry window.
+    _, fail_count = wit_client._failed_optional_holding_addrs[30407]
+    wit_client._failed_optional_holding_addrs[30407] = (
+        time.time() - _gm._VPP_HOLDING_RETRY_S - 1, fail_count,
+    )
+    assert wit_client._optional_holding_blocked(30407) is False
+
+    reads = FakeHoldingReads(values={30407: [1, 20, 65436, 1]})
+    data = _read_device_info(wit_client, reads)
+    assert 30407 in reads.starts()
+    assert data.vpp_remote_power_available is True
+    assert data.remote_power_control_enable == 1
+    assert wit_client._failed_optional_holding_addrs == {}
+
+
+def test_an_expired_entry_keeps_its_count(wit_client):
+    """Re-failing after expiry must increment, not restart, the streak - otherwise the
+    block oscillates between blocked and eligible forever and logs the transition each
+    time round."""
+    threshold = _gm._VPP_HOLDING_FAIL_THRESHOLD
+
+    for _ in range(threshold):
+        _read_device_info(wit_client, FakeHoldingReads(fail={30407}))
+    wit_client._failed_optional_holding_addrs[30407] = (
+        time.time() - _gm._VPP_HOLDING_RETRY_S - 1, threshold,
+    )
+
+    _read_device_info(wit_client, FakeHoldingReads(fail={30407}))
+    assert wit_client._failed_optional_holding_addrs[30407][1] == threshold + 1
+    assert wit_client._optional_holding_blocked(30407) is True
+
+
+# ---------------------------------------------------------------------------
+# Clear on (re-)connect
+# ---------------------------------------------------------------------------
+
+
+def test_reconnect_clears_both_blacklists():
+    hub = FakeHub()
+    client = _client(hub)
+    now = time.time()
+    client._failed_optional_ranges = {(31200, 24): (now, 4)}
+    client._failed_optional_holding_addrs = {30407: (now, 4), 30200: (now, 4)}
+
+    # Same connection: the state survives.
+    client._sync_optional_blacklists_with_connection()
+    assert client._failed_optional_holding_addrs != {}
+
+    hub.reconnect()
+    client._sync_optional_blacklists_with_connection()
+    assert client._failed_optional_ranges == {}
+    assert client._failed_optional_holding_addrs == {}
+
+
+def test_read_all_data_clears_blacklists_after_a_reconnect():
+    """The clear must be wired into the poll, not merely available as a helper."""
+    hub = FakeHub()
+    client = _client(hub)
+    # An empty profile makes read_all_data bail immediately after the sync step.
+    client.register_map = {"name": "STUB", "input_registers": {}, "holding_registers": {}}
+    client._failed_optional_holding_addrs = {30407: (time.time(), 9)}
+
+    hub.reconnect()
+    assert client.read_all_data() is None
+    assert client._failed_optional_holding_addrs == {}
+
+
+# ---------------------------------------------------------------------------
+# Why a read failed decides whether a reconnect re-arms it
+# ---------------------------------------------------------------------------
+
+
+def _fail_until_blocked(client, anchor, kind):
+    """Fail `anchor` enough consecutive polls that the backoff engages."""
+    for _ in range(_gm._VPP_HOLDING_FAIL_THRESHOLD):
+        _read_device_info(client, KindedHoldingReads(fail={anchor}, kind=kind, client=client))
+    assert client._optional_holding_blocked(anchor) is True
+
+
+def test_no_response_backoff_survives_a_reconnect():
+    """A register the inverter ignores must stay backed off across reconnects.
+
+    Otherwise the expensive case loops: a timed-out read closes the socket, the next poll
+    reconnects, the reconnect clears the backoff, and the unanswered read is armed again
+    for the very next poll - which is what the skip exists to avoid.
+    """
+    hub = FakeHub()
+    client = _client(hub)
+    _fail_until_blocked(client, 30407, _gm.ERROR_KIND_NO_RESPONSE)
+
+    hub.reconnect()
+    client._sync_optional_blacklists_with_connection()
+
+    assert client._optional_holding_blocked(30407) is True
+    reads = KindedHoldingReads(fail={30407}, kind=_gm.ERROR_KIND_NO_RESPONSE, client=client)
+    _read_device_info(client, reads)
+    assert 30407 not in reads.starts()
+
+
+def test_link_failure_backoff_is_cleared_by_a_reconnect():
+    """The point of the whole change: a dead socket must not silence the VPP blocks."""
+    hub = FakeHub()
+    client = _client(hub)
+    _fail_until_blocked(client, 30407, _gm.ERROR_KIND_LINK)
+
+    hub.reconnect()
+    client._sync_optional_blacklists_with_connection()
+
+    assert client._optional_holding_blocked(30407) is False
+    reads = KindedHoldingReads(values={30407: [1, 20, 65436, 1]}, client=client)
+    data = _read_device_info(client, reads)
+    assert 30407 in reads.starts()
+    assert data.vpp_remote_power_available is True
+    assert data.remote_power_control_enable == 1
+
+
+def test_unclassified_failure_is_treated_as_a_link_failure():
+    """Unknown provenance stays conservative - a transient error never sticks."""
+    hub = FakeHub()
+    client = _client(hub)
+    _fail_until_blocked(client, 30407, None)
+
+    hub.reconnect()
+    client._sync_optional_blacklists_with_connection()
+    assert client._optional_holding_blocked(30407) is False
+
+
+def test_a_poll_with_every_block_backed_off_reads_none_of_them():
+    """The skip still does its job: a poll must not pay for reads known not to answer."""
+    hub = FakeHub()
+    client = _client(hub)
+    for anchor in ANCHORS:
+        _fail_until_blocked(client, anchor, _gm.ERROR_KIND_NO_RESPONSE)
+
+    hub.reconnect()
+    client._sync_optional_blacklists_with_connection()
+
+    reads = KindedHoldingReads(fail=set(ANCHORS), kind=_gm.ERROR_KIND_NO_RESPONSE, client=client)
+    data = _read_device_info(client, reads)
+
+    assert not (set(ANCHORS) & set(reads.starts()))
+    # The poll still completed, and every block correctly reports "not read".
+    assert data.vpp_remote_power_available is False
+    assert data.vpp_export_limit_available is False
+    assert data.vpp_control_authority_available is False
+
+
+# ---------------------------------------------------------------------------
+# The hub classifies the two failure modes
+# ---------------------------------------------------------------------------
+
+
+class _FakeTcpClient:
+    """Just enough of a pymodbus TCP client for the hub's connect/close cycle.
+
+    pymodbus is a real test dependency, so an unpatched hub would genuinely dial
+    10.0.0.1:502 and block on the connect timeout. Patching the module-level name is the
+    idiom used by tests/test_serial_shared_connection.py for `ModbusClient`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.socket = None
+
+    def connect(self):
+        self.socket = object()
+        return True
+
+    def is_socket_open(self):
+        return self.socket is not None
+
+    def close(self):
+        # reset() only calls disconnect(), which does not drop the client object, so
+        # is_socket_open() going False here is what makes the next ensure_connected()
+        # open a genuinely new session and bump the generation.
+        self.socket = None
+
+
+@pytest.fixture
+def fake_tcp_client(monkeypatch):
+    monkeypatch.setattr(_gm, "ModbusTcpClient", _FakeTcpClient)
+    return _FakeTcpClient
+
+
+class _ErrorResponse:
+    def isError(self):  # noqa: N802 - pymodbus spelling
+        return True
+
+
+class _GoodResponse:
+    registers = [7]
+
+    def isError(self):  # noqa: N802 - pymodbus spelling
+        return False
+
+
+def test_shared_connection_bumps_generation_on_each_fresh_connect(fake_tcp_client):
+    hub = SharedModbusConnection("10.0.0.1", 502)
+    assert hub.connection_generation == 0
+
+    assert hub.ensure_connected() is True
+    assert hub.connection_generation == 1
+
+    # Socket already open - no new session, no bump.
+    assert hub.ensure_connected() is True
+    assert hub.connection_generation == 1
+
+    hub.reset("test")
+    assert hub.ensure_connected() is True
+    assert hub.connection_generation == 2
+
+
+def test_hub_reports_no_response_for_an_error_response(fake_tcp_client):
+    hub = SharedModbusConnection("10.0.0.1", 502)
+    hub.ensure_connected()
+    hub._client.read_holding_registers = lambda **kw: _ErrorResponse()
+
+    assert hub.read_holding_registers(30099, 1, 1) is None
+    assert hub.last_error_kind == _gm.ERROR_KIND_NO_RESPONSE
+
+
+def test_hub_reports_link_for_a_transport_exception(fake_tcp_client):
+    hub = SharedModbusConnection("10.0.0.1", 502)
+    hub.ensure_connected()
+
+    def boom(**kw):
+        raise OSError(32, "Broken pipe")
+
+    hub._client.read_holding_registers = boom
+
+    assert hub.read_holding_registers(30099, 1, 1) is None
+    assert hub.last_error_kind == _gm.ERROR_KIND_LINK
+
+
+def test_hub_clears_the_error_kind_on_success(fake_tcp_client):
+    hub = SharedModbusConnection("10.0.0.1", 502)
+    hub.ensure_connected()
+    hub.last_error_kind = _gm.ERROR_KIND_LINK
+    hub._client.read_holding_registers = lambda **kw: _GoodResponse()
+
+    assert hub.read_holding_registers(30099, 1, 1) == [7]
+    assert hub.last_error_kind is None
+
+
+# ---------------------------------------------------------------------------
+# A block that was not read must not reach the controls
+# ---------------------------------------------------------------------------
+
+
+def test_availability_map_covers_every_vpp_block_control():
+    flags = _const.VPP_CONTROL_AVAILABILITY_FLAG
+    data_fields = GrowattData().__dict__
+
+    for control_name, flag in flags.items():
+        assert control_name in _const.WRITABLE_REGISTERS, control_name
+        assert flag in data_fields, flag
+        assert control_name in data_fields, control_name
+
+    # Every control backed by one of the three optional blocks must be listed, or its
+    # entity goes on publishing the dataclass default.
+    expected = {
+        'control_authority': 'vpp_control_authority_available',
+        'vpp_export_limit_enable': 'vpp_export_limit_available',
+        'vpp_export_limit_power_rate': 'vpp_export_limit_available',
+        'remote_power_control_enable': 'vpp_remote_power_available',
+        'remote_power_control_charging_time': 'vpp_remote_power_available',
+        'remote_charge_and_discharge_power': 'vpp_remote_power_available',
+    }
+    assert flags == expected
+
+
+def test_control_entities_consult_the_availability_map():
+    """select.py / number.py cannot be imported without the full HA runtime, so the
+    wiring is checked at source level (the approach test_sensor_conditions.py uses)."""
+    from pathlib import Path
+
+    component_dir = Path(__file__).parent.parent / "custom_components" / "growatt_modbus"
+    for filename in ("select.py", "number.py"):
+        src = (component_dir / filename).read_text(encoding="utf-8")
+        assert "VPP_CONTROL_AVAILABILITY_FLAG" in src, filename
+        # Both the availability property and the value property must gate on it.
+        assert src.count("VPP_CONTROL_AVAILABILITY_FLAG.get(self._control_name)") == 2, filename
+        assert "def available(self) -> bool:" in src, filename


### PR DESCRIPTION
(#370 follow-up)

#370 made the optional-holding skip expire after 300 s, which fixed the permanent case: the anchor went into a set that was only ever added to, so one dropped frame latched "not supported by this firmware" for the life of the session.

The threshold stayed at one, and that is still enough to do damage. On a WIT on 2026-09-01T03:46:34Z a single transient read failure took 30407-30410 out of service. Reading those registers directly for the next 30 h returned correct values the whole time - the inverter was answering, the integration had simply stopped asking - while every entity derived from the block reported the GrowattData default, which is indistinguishable from a real "Disabled"/0 reading. Nothing in the log said the block had been skipped.

Three changes, all on top of the existing window rather than replacing it:

  * A block is skipped only after three CONSECUTIVE failures. A Modbus timeout on healthy hardware is routine; three in a row is evidence. A successful read resets the count, and an entry that has aged past the window keeps its count so a re-failure increments rather than restarting - otherwise the block oscillates and logs the transition each time round.

  * The failure is classified. #370 recorded the limitation openly: "a transport error and a genuine illegal data address are still conflated here, because read_holding_registers returns None for both". The shared hub now says which it was, so a reconnect re-arms the blocks that only failed because the socket was dead and leaves backed off the ones that went out on a working socket and were ignored. Re-arming those on every reconnect is the expensive loop the skip exists to avoid: an unanswered read closes the socket, the next poll reconnects, and the read is armed again. An unknown kind is treated as a link failure, which is the conservative direction.

  * A block that was not read publishes nothing. 30407-30410 gains the *_available flag that 30100 and 30200-30201 already had, and the generic number and select entities consult VPP_CONTROL_AVAILABILITY_FLAG in both available() and their value property. Unavailable, not a fabricated 0 - the control-side counterpart of withholding a sensor reading that was not taken. The value property is gated as well as availability because Home Assistant keeps the last state of an unavailable entity, so a 0 written there once would linger as a plausible-looking value.

Also counts an exception as a failure. read_holding_registers can raise as well as return None, and only the None path was recorded, so a block failing that way was retried at full price on every poll forever.

Defaults stay conservative in both directions: an inverter that genuinely does not implement these registers is asked once per 300 s exactly as before, and one that does is never taken out of service by a single error.

18 tests in tests/test_optional_holding_backoff.py, source-parsed for the entity wiring and behavioural for the rest. Confirmed red without the fix: setting the threshold back to 1 fails three of them, and removing the exception path fails a fourth. tests/test_vpp_holding_retry.py is unchanged and still passes - the retry window keeps its name and its value.