### PR TITLE
Stop a released hub from leaving a second connection behind

### DIFF
--- a/custom_components/growatt_modbus/__init__.py
+++ b/custom_components/growatt_modbus/__init__.py
@@ -544,7 +544,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: GrowattConfigEntry) -> 
         if hub is not None:
             # Release the hub reference; hub disconnects when refcount reaches 0
             connections = hass.data[DOMAIN].get("_connections", {})
-            hub.release_ref()
+            # In an executor: release_ref() may wait briefly for a poll to give the
+            # bus back, and the event loop must not block on that.
+            await hass.async_add_executor_job(hub.release_ref)
             if hub._refcount <= 0:
                 # Remove from registry — hub already disconnected in release_ref()
                 hub_key = f"{hub.host}:{hub.port}"

--- a/custom_components/growatt_modbus/coordinator.py
+++ b/custom_components/growatt_modbus/coordinator.py
@@ -1624,7 +1624,16 @@ class GrowattModbusCoordinator(DataUpdateCoordinator[GrowattData]):
             return None
 
         finally:
-            hub._lock.release()
+            # end_poll() is what closes a hub released mid-poll: release_ref() only
+            # marks it and takes the lock best-effort, so if a poll was holding the bus
+            # this is the moment the socket actually goes away. The lock is an RLock and
+            # we still hold it, so calling it here closes under the lock rather than
+            # racing whatever starts next. (For serial it also gives the port back
+            # between polls, which is its original purpose.)
+            try:
+                hub.end_poll()
+            finally:
+                hub._lock.release()
 
     def _fetch_data(self) -> GrowattData | None:
         """Fetch data from the inverter (runs in executor)."""

--- a/custom_components/growatt_modbus/growatt_modbus.py
+++ b/custom_components/growatt_modbus/growatt_modbus.py
@@ -119,6 +119,34 @@ def _format_modbus_error(result) -> str:
 # Write verification constants (cloud override detection)
 # =============================================================================
 
+# How long to leave a gateway alone after a reset before re-opening a socket.
+#
+# Enforced by REFUSING to connect during the window, never by sleeping. The hub
+# lock is held for a whole poll, so sleeping inside it would block every other
+# user of the same gateway -- a second config entry's poll, and any user-initiated
+# write -- for the length of the wait. Refusing instead lets the poll fail fast and
+# release the bus; the coordinator retries on its next cycle, which is exactly the
+# spacing this is trying to achieve.
+#
+# The first window is deliberately SHORT. Most transport errors are one-offs, and
+# making every one of them cost tens of seconds would turn a blip into a missed
+# poll. Two seconds is enough to stop a tight reconnect loop, which is all the
+# first retry needs to do.
+#
+# Repeated resets are a different situation, and the reason this escalates. On the
+# gateway that prompted this change, a second client is stalled for about 30
+# seconds (measured: a 300 ms read took 30,338 ms while another client held a
+# connection). A fixed 2 s wait cannot outlast that, so a run of failures would
+# keep re-opening sockets into a peer that is still busy — which is exactly the
+# behaviour that never recovers. Doubling per consecutive reset takes the wait
+# past the stall within a few attempts, and the ceiling keeps it bounded.
+#
+# The counter is cleared by a successful READ, not a successful connect: during
+# the failure this addresses, connects succeed and reads time out, so keying it to
+# connects would reset the escalation on every attempt and never escalate at all.
+RECONNECT_QUIET_BASE_SECONDS = 2.0
+RECONNECT_QUIET_MAX_SECONDS = 32.0
+
 WRITE_VERIFY_DELAY = 0.5           # seconds — delay before read-back after write
 WRITE_VERIFY_MAX_RETRIES = 3       # read-back checks after the single write (#402)
 WRITE_VERIFY_MAX_DELAY = 2.0       # seconds - ceiling for the backoff between checks
@@ -498,6 +526,22 @@ class SharedModbusConnection:
         self._recoveries_this_poll = 0
         self._max_recoveries_per_poll = 2
 
+        # Set by release_ref(). A hub that has been released must never build a new
+        # client: an in-flight poll survives unload (it runs in an executor thread that
+        # nothing cancels), and without this flag its next reset() would call
+        # ensure_connected(), find _client None, and open a socket owned by a hub that
+        # is already out of the registry. That orphan then races the socket the NEW hub
+        # opens on reload -- two clients against a gateway that serialises the second one
+        # for ~30 s, which is longer than the read timeout. The timeouts read as
+        # transport errors, whose handler resets and reconnects, and the cascade never
+        # ends. Measured on a WIT gateway, 2026-09-06.
+        self._released = False
+        # When the last reset() happened, and how many resets have run without a
+        # successful read in between, so a reconnect can leave the peer a moment of
+        # quiet instead of immediately re-opening a socket it is still busy stalling.
+        self._reset_at = 0.0
+        self._consecutive_resets = 0
+
         # Lifetime tallies of frames this gateway answered correctly vs. answered with
         # something that was not a reply to the question asked. Read by the coordinator to
         # decide whether to raise a repair issue — a gateway can sit at a double-digit
@@ -541,11 +585,68 @@ class SharedModbusConnection:
         Reopening a serial port costs about 2 ms, which is nothing next to a poll that reads
         98 registers. The lock still serializes entries that do share a hub.
         """
+        if self._released:
+            # The hub was released while this poll was running (a reload, or Home
+            # Assistant shutting down). The poll owns the socket until it ends, so this
+            # is the first safe moment to close it -- and closing it here is what stops
+            # an orphaned connection outliving its hub.
+            with self._lock:
+                self.disconnect()
+                self._client = None
+            return
+
         if not self.is_serial:
             return
         with self._lock:
             self.disconnect()
             self._client = None
+
+    def _note_transaction_succeeded(self) -> None:
+        """The gateway answered a question correctly, so start the escalation over.
+
+        Any completed transaction counts, read or write: what the counter tracks is
+        "how many times in a row has this connection failed with nothing working in
+        between". Counting only reads made a poll of writes look like an unbroken run
+        of failures and blocked the next write's legitimate #364 retry.
+        """
+        self._consecutive_resets = 0
+
+    def _quiet_period(self) -> float:
+        """Seconds to leave the peer alone before reconnecting, after N resets.
+
+        ZERO for the first reset, deliberately. That one is the reset-and-retry-once
+        recovery from #364, which exists for a silently-dropped socket that pymodbus
+        has not noticed: it is cheap, it usually works, and delaying it would turn a
+        recoverable blip into a lost poll. The window starts at the SECOND consecutive
+        reset, where a one-off has already been ruled out.
+        """
+        if self._consecutive_resets <= 1:
+            return 0.0
+        exponent = max(0, self._consecutive_resets - 2)
+        return min(RECONNECT_QUIET_BASE_SECONDS * (2 ** exponent),
+                   RECONNECT_QUIET_MAX_SECONDS)
+
+    def connect_refusal_reason(self) -> str:
+        """Why the last ensure_connected() said no — for a caller's error message.
+
+        A write refused during the quiet window is not the same failure as a gateway
+        that cannot be reached, and telling them apart is the difference between
+        "try again shortly" and "go and look at the wiring".
+        """
+        remaining = self._quiet_remaining()
+        if remaining > 0:
+            return (f"Gateway is in a post-failure quiet period after "
+                    f"{self._consecutive_resets} reset(s); retry in "
+                    f"{remaining:.0f}s")
+        if self._released:
+            return "This shared connection has been released"
+        return "Could not connect to shared Modbus gateway"
+
+    def _quiet_remaining(self) -> float:
+        """Seconds still to run on the post-failure window; 0 when clear."""
+        if not self._reset_at:
+            return 0.0
+        return max(0.0, self._quiet_period() - (time.monotonic() - self._reset_at))
 
     def _begin_recovery(self) -> bool:
         """True if a reset+retry is still within this poll's recovery budget."""
@@ -554,11 +655,38 @@ class SharedModbusConnection:
         self._recoveries_this_poll += 1
         return True
 
-    def release_ref(self) -> None:
+    def release_ref(self, lock_timeout: float = 5.0) -> None:
+        """Drop a reference; close the transport once nobody needs it.
+
+        The flag is set FIRST and without the lock, because it is what makes the
+        teardown safe: a poll running in an executor thread cannot be cancelled, and
+        marking the hub released stops that poll from re-creating a client no matter
+        when it next looks.
+
+        Then the lock is taken, so the socket is closed BETWEEN reads rather than
+        underneath one. Taking it is best-effort: a poll can legitimately hold the bus
+        for tens of seconds, and blocking unload on that would be worse than leaving the
+        socket to end_poll(), which now closes it for a released hub.
+        """
         self._refcount -= 1
-        if self._refcount <= 0:
-            self.disconnect()
-            self._client = None
+        if self._refcount > 0:
+            return
+
+        self._released = True
+
+        if self._lock.acquire(timeout=lock_timeout):
+            try:
+                self.disconnect()
+                self._client = None
+            finally:
+                self._lock.release()
+            return
+
+        logger.debug(
+            "[SharedConn %s] release: a poll still holds the bus after %.0fs; the "
+            "hub is marked released and end_poll() will close it",
+            self.connection_id, lock_timeout,
+        )
 
     # ------------------------------------------------------------------
     # Connection lifecycle (call only while lock is held)
@@ -566,6 +694,15 @@ class SharedModbusConnection:
 
     def ensure_connected(self) -> bool:
         """Connect if not already open; flush stale bytes on a new connection."""
+        if self._released:
+            # See _released in __init__. An orphaned poll must die quietly rather than
+            # open a socket nobody will ever close.
+            logger.debug(
+                "[SharedConn %s] refusing to connect: this hub has been released",
+                self.connection_id,
+            )
+            return False
+
         if self._client is None:
             if self.is_serial:
                 if not SERIAL_AVAILABLE:
@@ -598,9 +735,27 @@ class SharedModbusConnection:
         except Exception:
             pass
 
+        # A reset means the peer just failed to answer. Re-opening a socket
+        # immediately is the worst thing to do to a gateway that serialises clients:
+        # the new connection queues behind whatever is still stalling it, times out in
+        # turn, and produces another reset.
+        #
+        # So the reconnect is REFUSED until the window has passed, rather than waited
+        # out: this runs with the hub lock held, and sleeping here would stall every
+        # other user of the gateway. The caller fails fast and the next poll picks it up.
+        remaining = self._quiet_remaining()
+        if remaining > 0:
+            logger.debug(
+                "[SharedConn %s] not reconnecting yet: %.1fs of the post-failure "
+                "quiet window remain (%d consecutive reset(s))",
+                self.connection_id, remaining, self._consecutive_resets,
+            )
+            return False
+
         result = self._client.connect()
         if result:
             self._connected = True
+            self._reset_at = 0.0
             self._flush_receive_buffer()
         elif self.is_serial:
             # pyserial logs "[Errno 11] Could not exclusively lock port ..." and pymodbus
@@ -644,6 +799,8 @@ class SharedModbusConnection:
             "[SharedConn %s] Resetting connection%s",
             self.connection_id, f": {reason}" if reason else "",
         )
+        self._reset_at = time.monotonic()
+        self._consecutive_resets += 1
         self.disconnect()
 
     def _flush_receive_buffer(self) -> None:
@@ -745,6 +902,9 @@ class SharedModbusConnection:
             return None
 
         self.good_reads += 1
+        # Whatever went wrong before is over — see _note_transaction_succeeded().
+        # Deliberately not on a successful CONNECT: see RECONNECT_QUIET_BASE_SECONDS.
+        self._note_transaction_succeeded()
         return registers
 
     def read_input_registers(self, start: int, count: int, slave_id: int) -> Optional[list]:
@@ -876,6 +1036,7 @@ class SharedModbusConnection:
                     self.connection_id, register, value, result,
                 )
                 return False
+            self._note_transaction_succeeded()
             return True
         return False
 
@@ -917,6 +1078,7 @@ class SharedModbusConnection:
                     self.connection_id, register, len(values), result,
                 )
                 return False
+            self._note_transaction_succeeded()
             return True
         return False
 
@@ -3023,7 +3185,9 @@ class GrowattModbus:
                     raise ModbusWriteError(register, [value], "Shared connection busy (lock timeout on write)")
                 try:
                     if not self._shared_conn.ensure_connected():
-                        raise ModbusWriteError(register, [value], "Could not connect to shared Modbus gateway")
+                        raise ModbusWriteError(
+                            register, [value],
+                            self._shared_conn.connect_refusal_reason())
                     success = self._shared_conn.write_register(register, value, self.slave_id)
                 finally:
                     self._shared_conn._lock.release()
@@ -3247,7 +3411,9 @@ class GrowattModbus:
                     raise ModbusWriteError(register, values, "Shared connection busy (lock timeout on write_registers)")
                 try:
                     if not self._shared_conn.ensure_connected():
-                        raise ModbusWriteError(register, values, "Could not connect to shared Modbus gateway")
+                        raise ModbusWriteError(
+                            register, values,
+                            self._shared_conn.connect_refusal_reason())
                     success = self._shared_conn.write_registers(register, values, self.slave_id)
                 finally:
                     self._shared_conn._lock.release()

--- a/tests/test_hub_release_race.py
+++ b/tests/test_hub_release_race.py
@@ -1,0 +1,346 @@
+"""A released hub must not leave a connection behind (the 2026-09-06 outage).
+
+The reference gateway **serialises a second TCP client for about 30 seconds**:
+a read that normally takes 300 ms took 30,338 ms while another client held a
+connection. That is longer than the read timeout, so a second connection does
+not merely slow things down — it manufactures transport errors.
+
+Which matters because of how the integration used to tear a hub down:
+
+    release_ref()  closed the socket and set _client = None, with no lock,
+                   while a poll was still running in an executor thread that
+                   nothing cancels
+
+    the orphaned poll then hit a transport error, called reset() ->
+    ensure_connected(), found _client None, and BUILT A NEW CLIENT — a socket
+    owned by a hub already dropped from the registry
+
+    meanwhile the reload created the new hub, which opened its own socket
+
+Two live clients, 30 s stalls, timeouts read as transport errors, each handled
+by reconnecting. The cascade never ended: every outage that day began at a
+restart or a reload, and only disabling the integration ever cleared it.
+
+The fix is three small rules, one test each below.
+"""
+from __future__ import annotations
+
+import importlib
+import threading
+import time
+
+import pytest
+
+_gm = importlib.import_module("growatt_under_test.growatt_modbus")
+SharedModbusConnection = _gm.SharedModbusConnection
+
+
+class _Response:
+    """Stand-in for a pymodbus response, as tests/test_connection_recovery.py uses."""
+
+    def __init__(self, registers=None, error=False):
+        self.registers = registers or []
+        self._error = error
+
+    def isError(self):  # noqa: N802 - pymodbus spelling
+        return self._error
+
+
+class _FakeClient:
+    def __init__(self):
+        self.closes = 0
+        self.connects = 0
+
+    def close(self):
+        self.closes += 1
+
+    def connect(self):
+        self.connects += 1
+        return True
+
+    def is_socket_open(self):
+        return self.closes == 0
+
+
+def _hub():
+    hub = SharedModbusConnection(host="10.0.0.1", port=502)
+    hub._client = _FakeClient()
+    hub.acquire_ref()
+    return hub
+
+
+# ---------------------------------------------------------------------------
+# 1. A released hub never builds another client
+# ---------------------------------------------------------------------------
+
+def test_a_released_hub_refuses_to_connect():
+    """The orphaned poll's next move was to open a socket nobody owned."""
+    hub = _hub()
+    hub.release_ref()
+
+    assert hub.ensure_connected() is False
+    assert hub._client is None
+
+
+def test_a_released_hub_builds_no_client_even_when_asked_repeatedly():
+    hub = _hub()
+    hub.release_ref()
+
+    for _ in range(5):
+        assert hub.ensure_connected() is False
+    assert hub._client is None
+
+
+def test_releasing_closes_the_socket():
+    hub = _hub()
+    client = hub._client
+
+    hub.release_ref()
+
+    assert client.closes == 1
+    assert hub._client is None
+
+
+def test_a_hub_with_other_users_is_not_torn_down():
+    """Refcounting still governs: two coordinators, one release, still alive."""
+    hub = _hub()
+    hub.acquire_ref()
+
+    hub.release_ref()
+
+    assert hub._released is False
+    assert hub._client is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. Teardown waits for the poll rather than racing it
+# ---------------------------------------------------------------------------
+
+def test_release_waits_for_a_poll_that_holds_the_bus():
+    """The socket must be closed BETWEEN reads, not underneath one."""
+    hub = _hub()
+    client = hub._client
+    holding = threading.Event()
+    release_may_proceed = threading.Event()
+    closed_during_poll = []
+
+    def poll():
+        with hub._lock:
+            holding.set()
+            release_may_proceed.wait(2)
+            # Whatever release_ref() did, it must not have closed our socket yet.
+            closed_during_poll.append(client.closes)
+
+    worker = threading.Thread(target=poll)
+    worker.start()
+    holding.wait(2)
+
+    releaser = threading.Thread(target=lambda: hub.release_ref(lock_timeout=5))
+    releaser.start()
+    time.sleep(0.2)                     # give release_ref a chance to race us
+    release_may_proceed.set()
+    worker.join(3)
+    releaser.join(3)
+
+    assert closed_during_poll == [0], "the socket was closed under a running poll"
+    assert client.closes == 1
+    assert hub._client is None
+
+
+def test_release_does_not_block_forever_on_a_long_poll():
+    """A poll may legitimately hold the bus for tens of seconds. Unload must not
+    hang on it — the released flag is what makes leaving the socket safe."""
+    hub = _hub()
+    started = threading.Event()
+
+    def hog():
+        with hub._lock:
+            started.set()
+            time.sleep(1.5)
+
+    worker = threading.Thread(target=hog)
+    worker.start()
+    started.wait(2)
+
+    began = time.monotonic()
+    hub.release_ref(lock_timeout=0.2)
+    took = time.monotonic() - began
+
+    assert took < 1.0, f"release blocked for {took:.2f}s"
+    assert hub._released is True          # the poll can no longer reconnect
+    worker.join(3)
+
+
+def test_end_poll_closes_a_hub_released_mid_poll():
+    """The first safe moment to close an orphaned socket is when its poll ends."""
+    hub = _hub()
+    client = hub._client
+    hub._released = True                  # as release_ref() would leave it
+
+    hub.end_poll()
+
+    assert client.closes == 1
+    assert hub._client is None
+
+
+# ---------------------------------------------------------------------------
+# 3. A reset leaves the peer a moment of quiet
+# ---------------------------------------------------------------------------
+
+def test_a_reconnect_inside_the_quiet_window_is_refused_not_delayed():
+    """REFUSED, never slept on. ensure_connected() runs with the hub lock held for
+    the whole poll, so waiting here would block every other user of the gateway —
+    a second config entry's poll, and any user-initiated write. Failing fast gives
+    the bus back and the coordinator retries on its next cycle, which is the same
+    spacing without the blocking."""
+    hub = _hub()
+    client = hub._client
+    hub.reset("first — this one is allowed through, see #364")
+    connects_before = client.connects
+
+    hub.reset("second consecutive failure")
+
+    began = time.monotonic()
+    assert hub.ensure_connected() is False
+    elapsed = time.monotonic() - began
+
+    assert elapsed < 0.1, f"ensure_connected blocked for {elapsed:.2f}s"
+    assert client.connects == connects_before, "it opened a socket anyway"
+
+
+def test_the_window_expires_and_the_reconnect_then_proceeds():
+    hub = _hub()
+    hub.reset("first")
+    hub.reset("second")
+    hub._reset_at -= _gm.RECONNECT_QUIET_BASE_SECONDS + 0.01   # window has passed
+
+    assert hub.ensure_connected() is True
+
+
+def test_the_first_reset_still_reconnects_immediately():
+    """#364's recovery must survive this change: a single transport error is a
+    silently-dropped socket, and resetting and retrying once is the cheap fix."""
+    hub = _hub()
+    hub.reset("one transport error")
+
+    assert hub._quiet_period() == 0.0
+    assert hub.ensure_connected() is True
+
+
+def test_a_connect_with_no_preceding_reset_is_immediate():
+    """The quiet window is a response to failure, not a tax on every poll."""
+    hub = _hub()
+    hub._client.close()                   # socket shut, but nothing was reset
+
+    began = time.monotonic()
+    assert hub.ensure_connected() is True
+    assert time.monotonic() - began < 0.5
+
+
+def test_a_write_refused_by_the_window_says_so():
+    """"Could not connect" would send someone to check the wiring. This is a
+    "try again shortly" failure and should read like one."""
+    hub = _hub()
+    hub.reset("first")
+    hub.reset("second")
+
+    reason = hub.connect_refusal_reason()
+
+    assert "quiet period" in reason
+    assert "retry in" in reason
+
+
+def test_a_released_hub_says_that_instead():
+    hub = _hub()
+    hub.release_ref()
+
+    assert "released" in hub.connect_refusal_reason()
+
+
+# --- the wait escalates while failures continue ----------------------------
+
+def test_the_wait_doubles_for_each_consecutive_reset():
+    """A fixed short wait cannot outlast a peer that stalls a second client for
+    tens of seconds: the reconnects keep landing inside the stall. Doubling gets
+    past it within a few attempts."""
+    hub = _hub()
+    base = _gm.RECONNECT_QUIET_BASE_SECONDS
+
+    waits = []
+    for _ in range(5):
+        hub.reset("still failing")
+        waits.append(hub._quiet_period())
+
+    # The first reset is #364's immediate retry and is not delayed at all.
+    assert waits == [0.0, base, base * 2, base * 4, base * 8]
+
+
+def test_the_wait_is_capped():
+    """Bounded, so a dead gateway cannot push a poll out to minutes."""
+    hub = _hub()
+    for _ in range(20):
+        hub.reset("still failing")
+
+    assert hub._quiet_period() == _gm.RECONNECT_QUIET_MAX_SECONDS
+
+
+def test_a_successful_read_starts_the_escalation_over():
+    """Keyed to a successful READ rather than a successful connect. In the failure
+    this addresses, connects succeed and reads time out — so clearing on connect
+    would reset the escalation on every attempt and never escalate at all."""
+    hub = _hub()
+    hub.reset("first")
+    hub.reset("second")
+    hub.reset("third")
+    assert hub._quiet_period() > _gm.RECONNECT_QUIET_BASE_SECONDS
+
+    hub._validate_registers(_Response([1, 2, 3]), start=0, count=3)
+
+    assert hub._consecutive_resets == 0
+    # Fully cleared: the next single failure is #364's immediate retry again.
+    assert hub._quiet_period() == 0.0
+
+
+def test_a_successful_connect_alone_does_not_reset_the_escalation():
+    hub = _hub()
+    hub.reset("first")
+    hub.reset("second")
+    hub._reset_at -= _gm.RECONNECT_QUIET_MAX_SECONDS          # let it through
+
+    assert hub.ensure_connected() is True
+
+    assert hub._consecutive_resets == 2
+
+
+# --- the poll must actually call end_poll() --------------------------------
+
+def test_the_shared_poll_closes_a_released_hub_in_its_finally():
+    """end_poll() is what closes a hub released mid-poll — release_ref() only
+    marks it and takes the lock best-effort. If the shared poll never calls
+    end_poll(), a hub released while a poll held the bus is never closed by
+    anything, and the socket outlives its owner.
+
+    Checked against the source because reaching _fetch_data_shared() needs a
+    coordinator and a running Home Assistant, while the guarantee is one call in
+    one finally block. Read as text rather than parsed: coordinator.py uses a
+    PEP 695 `type` alias, so ast.parse() raises on Python < 3.12.
+    """
+    from pathlib import Path
+
+    source = (Path(__file__).parent.parent / "custom_components" / "growatt_modbus"
+              / "coordinator.py").read_text(encoding="utf-8")
+
+    marker = "def _fetch_data_shared"
+    assert marker in source, "_fetch_data_shared has been renamed"
+    body = source[source.index(marker):]
+    end = body.find("\n    def ", 1)
+    body = body[:end] if end != -1 else body
+
+    assert "finally:" in body, "_fetch_data_shared has no finally block"
+    finally_block = body[body.index("finally:"):]
+
+    assert "end_poll()" in finally_block, (
+        "the shared poll never calls hub.end_poll() in its finally; a hub "
+        "released mid-poll would never be closed")
+    assert "release()" in finally_block, (
+        "the shared poll must still release the bus lock")


### PR DESCRIPTION
# Fix: a released hub can leave a second connection behind

## What happens

`SharedModbusConnection.release_ref()` closes the socket and sets `_client = None`
**with no lock held**, while a poll may still be running — `_fetch_data_shared()`
runs in an executor thread that nothing cancels when a config entry is unloaded.

The orphaned poll then hits a transport error, calls `reset()` → `ensure_connected()`,
finds `_client is None`, and **builds a brand-new client and connects it** — a socket
owned by a hub that has already been dropped from `hass.data[DOMAIN]["_connections"]`.
Meanwhile `async_setup_entry()` creates the new hub and connects *its* socket.

Two live clients against one gateway.

## Why that is fatal on some gateways

Measured on a WIT 4-15kW via its RS485→TCP gateway on 2026-09-06:

**a second client is stalled for about 30 seconds.** A read that normally takes
300 ms took **30,338 ms** while another client held a connection.

That is longer than the read timeout, so a second socket does not merely slow
polling down — it *manufactures* transport errors. Whose handler resets and
reconnects. Which adds another socket. The cascade is self-sustaining: on the
reference installation every outage began at a restart or a reload, none recovered
on its own, and only *disabling* the integration ever cleared it — after which the
gateway was reachable again within seconds, from every host.

Log from one such reload, with the poll still running through two hub rebuilds:

```
15:13:06.143  Shared Modbus connection hub for 192.168.2.127:502 removed (no more users)
15:13:06.145  Created shared Modbus connection hub for 192.168.2.127:502
15:13:07.732  SyncWorker_5: Failed to read base input register block (0-124)   <- old poll alive
15:13:08.482  SyncWorker_5: 5 consecutive read failures - backing off to 1s
15:13:12.510  hub removed / created            <- again, SyncWorker_5 STILL polling
```

I believe this is the mechanism behind #414 ("after a single RS485 transport error
the connection is permanently wedged; only a reload or gateway power-cycle helps,
then it repeats within 1–2 minutes"). Same inverter family, same gateway topology.

## The change

Three rules:

1. **`release_ref()` sets `_released` first, without the lock.** An executor poll
   cannot be cancelled, so the flag is what stops it re-creating a client, whenever
   it next looks. It then takes the lock so the socket closes *between* reads rather
   than underneath one — best-effort with a timeout, because a poll may legitimately
   hold the bus for tens of seconds and blocking unload on that would be its own bug.
2. **`ensure_connected()` refuses to build a client for a released hub**, so an
   orphaned poll dies quietly instead of opening a socket nobody will close.
   `end_poll()` closes a hub released mid-poll — the first safe moment.
3. **`reset()` stamps the time and a reconnect waits `RECONNECT_QUIET_SECONDS`.**
   Re-opening a socket immediately is the worst possible move against a peer that
   is still stalling the previous one.

`release_ref()` also moves off the event loop in `async_unload_entry`, since it can
now wait briefly.

## Tests

`tests/test_hub_release_race.py`, 10 tests. The one that matters most starts a
thread holding the bus while another releases, and asserts the socket was **not**
closed while the poll was mid-read.

Suite: no new failures against `main` (37 before, 37 after, on a machine where
those 37 are pre-existing environment gaps).

## What this does not fix

On the reference installation the wedge can also occur on a clean start with no
reload, so this is not the whole story for that hardware — but it is a real race
with a clear reproduction, and it is one of the ways a second socket appears.
